### PR TITLE
[FIX] Google Maps 초기화 버그 수정 및 로딩 UX 개선

### DIFF
--- a/client/src/features/googleMap/hooks/useGoogleMap.ts
+++ b/client/src/features/googleMap/hooks/useGoogleMap.ts
@@ -13,7 +13,9 @@ export const useGoogleMap = () => {
 
   useEffect(() => {
     const initMap = () => {
-      initializeMap({ mapRef, setMapInstance, setService, findNearbyPlaces });
+      initializeMap({ mapRef, setMapInstance, setService, findNearbyPlaces }).catch((error) => {
+        console.error('Google Maps 초기화 실패:', error);
+      });
     };
 
     const handleLanguageChange = () => {

--- a/client/src/features/googleMap/ui/GoogleMaps.tsx
+++ b/client/src/features/googleMap/ui/GoogleMaps.tsx
@@ -18,6 +18,13 @@ export default function GoogleMaps() {
       </button>
 
       <div ref={mapRef} className='h-full w-full' />
+
+      {!mapInstance && (
+        <div className='absolute inset-0 flex flex-col items-center justify-center gap-3 bg-gray-100'>
+          <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500' />
+          <p className='text-sm text-gray-500'>지도를 불러오는 중...</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/features/googleMap/utils/initializeMap.ts
+++ b/client/src/features/googleMap/utils/initializeMap.ts
@@ -55,27 +55,26 @@ export const initializeMap = async ({
     return;
   }
 
-  navigator.permissions
+  const permissionState = await navigator.permissions
     ?.query({ name: 'geolocation' })
-    .then((result) => {
-      if (result.state === 'denied') {
-        console.warn('Geolocation permission denied. Using default location.');
-        initializeMapWithDefaultLocation();
-        return;
-      }
-    })
-    .catch(() => {
-      // Permissions API not supported, continue with getCurrentPosition
-    });
+    .catch(() => null);
+
+  if (permissionState?.state === 'denied') {
+    console.warn('Geolocation permission denied. Using default location.');
+    initializeMapWithDefaultLocation();
+    return;
+  }
 
   navigator.geolocation.getCurrentPosition(
     (position) => {
+      if (!mapRef.current) return;
+
       const center = {
         lat: position.coords.latitude,
         lng: position.coords.longitude,
       };
 
-      const map = new Map(mapRef.current as HTMLDivElement, {
+      const map = new Map(mapRef.current, {
         center,
         zoom: 15,
         mapId: 'NEXT_MAPS_VITALTRIPS',
@@ -115,13 +114,14 @@ export const initializeMap = async ({
   );
 
   function initializeMapWithDefaultLocation() {
-    // Default to Seoul, Korea coordinates
+    if (!mapRef.current) return;
+
     const defaultCenter = {
       lat: 37.5665,
       lng: 126.978,
     };
 
-    const map = new Map(mapRef.current as HTMLDivElement, {
+    const map = new Map(mapRef.current, {
       center: defaultCenter,
       zoom: 13,
       mapId: 'NEXT_MAPS_VITALTRIPS',


### PR DESCRIPTION
## Summary

- `initializeMap`: 위치 권한 `denied` 시 `getCurrentPosition`까지 이중 실행되던 버그 수정 (`await`로 직렬화)
- `initializeMap` / `useGoogleMap`: `mapRef.current` null 체크 추가 및 async 에러 캐치 누락 수정
- `GoogleMaps`: 지도 초기화 완료 전 검은 화면 대신 로딩 스피너 표시

## Test plan

- [ ] 위치 권한 허용 → 현재 위치로 지도 정상 로딩 확인
- [ ] 위치 권한 거부 → 서울 기본 위치로 지도 로딩 확인 (이중 초기화 없음)
- [ ] 지도 로딩 중 스피너가 표시되고, 완료 후 사라지는지 확인
- [ ] 페이지 빠르게 이탈 시 콘솔 에러 없는지 확인