### PR TITLE
[FEAT] 지도 카테고리/재검색 기능, 여행경보 다국어 지원

### DIFF
--- a/client/app/about/[lang]/page.tsx
+++ b/client/app/about/[lang]/page.tsx
@@ -76,7 +76,7 @@ export default async function AboutLangPage({ params }: PageProps) {
 
   return (
     <div className='min-h-screen overflow-x-hidden md:pt-16'>
-      <Navbar />
+      <Navbar navTranslations={translations.navbar} />
       <HeroSection translations={translations} />
       <FeaturesSection translations={translations} />
 

--- a/client/app/about/_data/aboutTranslation.ts
+++ b/client/app/about/_data/aboutTranslation.ts
@@ -1,5 +1,13 @@
 export const aboutTranslations = {
   en: {
+    navbar: {
+      home: 'Home',
+      about: 'About',
+      news: 'News',
+      translate: 'AI Translation',
+      first_aid: 'AI First Aid',
+      hospital_pharmacy_nearby: 'Hospital & Pharmacy Nearby',
+    },
     meta: {
       title: 'About VitalTrip - Your Essential Travel Safety Companion',
       description:
@@ -79,6 +87,14 @@ export const aboutTranslations = {
     },
   },
   ko: {
+    navbar: {
+      home: '홈',
+      about: '소개',
+      news: '뉴스',
+      translate: 'AI 번역',
+      first_aid: 'AI 응급처치',
+      hospital_pharmacy_nearby: '병원 & 약국 찾기',
+    },
     meta: {
       title: 'VitalTrip 소개 - 필수 여행 안전 동반자',
       description:

--- a/client/app/alerts/[countryCode]/page.tsx
+++ b/client/app/alerts/[countryCode]/page.tsx
@@ -1,9 +1,7 @@
 import { fetchTravelAlertByCountry } from '@/src/features/travelAlert/services/travelAlertService';
 import { ALARM_LEVEL } from '@/src/features/travelAlert/types/travelAlert';
-import { TravelAlertContent } from '@/src/features/travelAlert/ui/TravelAlertContent';
+import { TravelAlertCountryClient } from '@/src/features/travelAlert/ui/TravelAlertCountryClient';
 import { Metadata } from 'next';
-import Image from 'next/image';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 interface Props {
@@ -15,13 +13,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const items = await fetchTravelAlertByCountry(countryCode);
   const country = items?.[0];
 
-  if (!country) return { title: '여행경보 정보' };
+  if (!country) return { title: 'Travel Alert | VitalTrip' };
 
   const alarmInfo = ALARM_LEVEL[country.alarm_lvl as keyof typeof ALARM_LEVEL];
 
   return {
-    title: `${country.country_nm} 여행경보 | VitalTrip`,
-    description: `${country.country_nm} 현재 여행경보: ${alarmInfo?.label ?? '정보 없음'}. 해외 여행 전 안전 정보를 확인하세요.`,
+    title: `${country.country_eng_nm} Travel Alert | VitalTrip`,
+    description: `${country.country_eng_nm} current travel alert: ${alarmInfo?.label ?? 'No information'}. Check safety information before traveling abroad.`,
   };
 }
 
@@ -31,48 +29,5 @@ export default async function TravelAlertPage({ params }: Props) {
 
   if (!items || items.length === 0) notFound();
 
-  const country = items[0];
-  const alarmInfo = ALARM_LEVEL[country.alarm_lvl as keyof typeof ALARM_LEVEL];
-
-  return (
-    <div className='min-h-screen bg-slate-50'>
-      <header className='w-full bg-white shadow-sm'>
-        <div className='mx-auto max-w-4xl px-6 py-5'>
-          <div className='flex items-center gap-3'>
-            <Link href='/' aria-label='VitalTrip 홈으로 이동'>
-              <Image
-                src='/VitalTrip.svg'
-                alt='VitalTrip'
-                width={40}
-                height={40}
-                className='h-10 w-auto'
-              />
-            </Link>
-            <span className='text-lg font-semibold text-gray-700'>해외 여행경보</span>
-          </div>
-        </div>
-      </header>
-
-      <main className='mx-auto max-w-4xl px-6 py-10 pb-[100px]'>
-        <div className='mb-8 overflow-hidden rounded-2xl bg-white shadow-xl'>
-          <div className='flex items-center gap-6 p-8'>
-            {country.flag_download_url && (
-              <img
-                src={country.flag_download_url}
-                alt={`${country.country_nm} 국기`}
-                className='h-16 w-24 rounded-lg object-cover shadow-md'
-              />
-            )}
-            <div>
-              <p className='text-sm text-gray-600'>{country.continent_nm}</p>
-              <h1 className='text-3xl font-bold text-gray-900'>{country.country_nm}</h1>
-              <p className='text-lg text-gray-600'>{country.country_eng_nm}</p>
-            </div>
-          </div>
-        </div>
-
-        <TravelAlertContent items={items} alarmInfo={alarmInfo} />
-      </main>
-    </div>
-  );
+  return <TravelAlertCountryClient items={items} />;
 }

--- a/client/app/alerts/page.tsx
+++ b/client/app/alerts/page.tsx
@@ -1,13 +1,10 @@
+import { AlertsPageClient } from '@/src/features/travelAlert/ui/AlertsPageClient';
 import { fetchAllAlertCountries } from '@/src/features/travelAlert/services/travelAlertService';
-import { ALARM_LEVEL } from '@/src/features/travelAlert/types/travelAlert';
-import { CountrySearchClient } from '@/src/features/travelAlert/ui/CountrySearchClient';
 import { Metadata } from 'next';
-import Image from 'next/image';
-import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: '해외 여행경보 검색 | VitalTrip',
-  description: '외교부 공식 여행경보 정보. 여행 전 목적지 안전 정보를 확인하세요.',
+  title: 'Overseas Travel Alert | VitalTrip',
+  description: 'Official travel alert information. Check destination safety before you travel.',
 };
 
 export default async function AlertsPage() {
@@ -15,53 +12,11 @@ export default async function AlertsPage() {
 
   const levelCounts = countries.reduce(
     (acc, c) => {
-      const lvl = c.alarm_lvl;
-      acc[lvl] = (acc[lvl] ?? 0) + 1;
+      acc[c.alarm_lvl] = (acc[c.alarm_lvl] ?? 0) + 1;
       return acc;
     },
     {} as Record<string, number>,
   );
 
-  return (
-    <div className='min-h-screen bg-slate-50'>
-      <header className='w-full bg-white shadow-sm'>
-        <div className='mx-auto max-w-5xl px-6 py-5'>
-          <div className='flex items-center gap-3'>
-            <Link href='/' aria-label='VitalTrip 홈으로 이동'>
-              <Image
-                src='/VitalTrip.svg'
-                alt='VitalTrip'
-                width={40}
-                height={40}
-                className='h-10 w-auto'
-              />
-            </Link>
-            <span className='text-lg font-semibold text-gray-700'>해외 여행경보</span>
-          </div>
-        </div>
-      </header>
-
-      <main className='mx-auto max-w-5xl px-6 py-10 pb-[100px]'>
-        <div className='mb-8'>
-          <h1 className='text-3xl font-bold text-gray-900'>해외 여행경보 검색</h1>
-          <p className='mt-2 text-gray-600'>
-            외교부 공식 데이터 기준 · 총 {countries.length}개국 경보 발령 중
-          </p>
-        </div>
-
-        <div className='mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4'>
-          {Object.entries(ALARM_LEVEL).map(([level, { label, bg, text, border }]) => (
-            <div key={level} className={`rounded-xl border-2 ${border} ${bg} p-4 text-center`}>
-              <div className={`text-2xl font-bold ${text}`}>{levelCounts[level] ?? 0}</div>
-              <div className={`text-sm font-medium ${text}`}>
-                {level}단계 · {label}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <CountrySearchClient countries={countries} />
-      </main>
-    </div>
-  );
+  return <AlertsPageClient countries={countries} levelCounts={levelCounts} />;
 }

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -70,6 +70,10 @@
     "select": "Select",
     "close": "Close"
   },
+  "map": {
+    "category_all": "All",
+    "research_area": "Search this area"
+  },
   "medical": {
     "title": "Medical Facilities",
     "subtitle": "Find healthcare services near you",
@@ -91,6 +95,31 @@
       "pharmacy": "Pharmacy",
       "emergency": "Emergency"
     }
+  },
+  "travelAlert": {
+    "header_title": "Overseas Travel Alert",
+    "page_title": "Overseas Travel Alert Search",
+    "page_description": "Based on official Ministry of Foreign Affairs data · {{count}} countries with travel alerts issued",
+    "alarm_levels": {
+      "1": "Travel Advisory",
+      "2": "Travel Restraint",
+      "3": "Departure Recommended",
+      "4": "Travel Prohibited"
+    },
+    "level_count": "Level {{level}}",
+    "ministry_designation": "Ministry of Foreign Affairs designated travel alert level",
+    "regional_detail_title": "Regional Alert Details",
+    "total_regions": "{{count}} regions",
+    "all_regions": "All Regions",
+    "updated_date": "Updated: {{date}}",
+    "danger_map": "Danger Map",
+    "alert_level_guide": "Travel Alert Level Guide",
+    "level_label": "Level {{level}}",
+    "search_placeholder": "Search by country (e.g., Japan, JP)",
+    "search_results": "\"{{query}}\" — {{count}} results",
+    "total_countries": "{{count}} countries total",
+    "no_results": "No results found",
+    "source": "Source: Korea Ministry of Foreign Affairs Safe Travel"
   },
   "firstaid": {
     "reported_symptoms": "Symptoms you described",

--- a/client/public/locales/ko/common.json
+++ b/client/public/locales/ko/common.json
@@ -70,6 +70,10 @@
     "select": "선택",
     "close": "닫기"
   },
+  "map": {
+    "category_all": "전체",
+    "research_area": "이 지역 재검색"
+  },
   "medical": {
     "title": "의료 시설",
     "subtitle": "근처의 의료 서비스를 찾아보세요",
@@ -91,6 +95,31 @@
       "pharmacy": "약국",
       "emergency": "응급실"
     }
+  },
+  "travelAlert": {
+    "header_title": "해외 여행경보",
+    "page_title": "해외 여행경보 검색",
+    "page_description": "외교부 공식 데이터 기준 · 총 {{count}}개국 경보 발령 중",
+    "alarm_levels": {
+      "1": "여행유의",
+      "2": "여행자제",
+      "3": "출국권고",
+      "4": "여행금지"
+    },
+    "level_count": "{{level}}단계",
+    "ministry_designation": "외교부 지정 여행경보 단계",
+    "regional_detail_title": "지역별 경보 상세",
+    "total_regions": "총 {{count}}개 지역",
+    "all_regions": "전 지역",
+    "updated_date": "갱신일: {{date}}",
+    "danger_map": "위험지도",
+    "alert_level_guide": "여행경보 단계 안내",
+    "level_label": "{{level}}단계",
+    "search_placeholder": "국가명 검색 (예: 일본, Japan, JP)",
+    "search_results": "\"{{query}}\" 검색 결과 {{count}}개",
+    "total_countries": "전체 {{count}}개국",
+    "no_results": "검색 결과가 없어요",
+    "source": "출처: 외교부 해외안전여행"
   },
   "firstaid": {
     "reported_symptoms": "설명하신 증상",

--- a/client/src/features/googleMap/hooks/useGoogleMapSearch.ts
+++ b/client/src/features/googleMap/hooks/useGoogleMapSearch.ts
@@ -1,6 +1,10 @@
+'use client';
+
+import { useTranslation } from '@/src/shared/lib/i18n';
 import { useEffect, useState } from 'react';
 
 export const useGoogleMapSearch = () => {
+  const { i18n } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState<google.maps.places.AutocompletePrediction[]>([]);
   const [autocompleteService, setAutocompleteService] =
@@ -8,24 +12,27 @@ export const useGoogleMapSearch = () => {
 
   useEffect(() => {
     if (!autocompleteService && window.google?.maps?.places) {
-      const newService = new google.maps.places.AutocompleteService();
-      setAutocompleteService(newService);
+      setAutocompleteService(new google.maps.places.AutocompleteService());
     }
 
-    if (searchTerm && autocompleteService) {
+    if (!searchTerm) {
+      setSuggestions([]);
+      return;
+    }
+
+    if (!autocompleteService) return;
+
+    const timer = setTimeout(() => {
       autocompleteService.getPlacePredictions(
-        {
-          input: searchTerm,
-          language: 'en',
-        },
+        { input: searchTerm, language: i18n.language || 'en' },
         (predictions) => {
           if (predictions) setSuggestions(predictions);
         },
       );
-    } else if (!searchTerm) {
-      setSuggestions([]);
-    }
-  }, [searchTerm, autocompleteService]);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchTerm, autocompleteService, i18n.language]);
 
   return { searchTerm, setSearchTerm, suggestions, setSuggestions };
 };

--- a/client/src/features/googleMap/hooks/useMapControls.ts
+++ b/client/src/features/googleMap/hooks/useMapControls.ts
@@ -24,7 +24,12 @@ export const useMapControls = (
   const handleResearch = () => {
     if (!mapInstance || !service) return;
     const center = mapInstance.getCenter()!;
-    findNearbyPlaces(service, { lat: center.lat(), lng: center.lng() }, mapInstance, getTypes(activeCategory));
+    findNearbyPlaces(
+      service,
+      { lat: center.lat(), lng: center.lng() },
+      mapInstance,
+      getTypes(activeCategory),
+    );
     setShowResearchBtn(false);
   };
 
@@ -32,7 +37,12 @@ export const useMapControls = (
     setActiveCategory(category);
     if (!mapInstance || !service) return;
     const center = mapInstance.getCenter()!;
-    findNearbyPlaces(service, { lat: center.lat(), lng: center.lng() }, mapInstance, getTypes(category));
+    findNearbyPlaces(
+      service,
+      { lat: center.lat(), lng: center.lng() },
+      mapInstance,
+      getTypes(category),
+    );
   };
 
   return { showResearchBtn, activeCategory, handleResearch, handleCategoryChange };

--- a/client/src/features/googleMap/hooks/useMapControls.ts
+++ b/client/src/features/googleMap/hooks/useMapControls.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { findNearbyPlaces } from '../utils/findNearbyPlaces';
+
+export type CategoryKey = 'all' | 'pharmacy' | 'hospital';
+
+const getTypes = (category: CategoryKey): string[] =>
+  category === 'all' ? ['pharmacy', 'hospital'] : [category];
+
+export const useMapControls = (
+  mapInstance: google.maps.Map | null,
+  service: google.maps.places.PlacesService | null,
+) => {
+  const [showResearchBtn, setShowResearchBtn] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<CategoryKey>('all');
+
+  useEffect(() => {
+    if (!mapInstance) return;
+    const listener = mapInstance.addListener('dragend', () => setShowResearchBtn(true));
+    return () => google.maps.event.removeListener(listener);
+  }, [mapInstance]);
+
+  const handleResearch = () => {
+    if (!mapInstance || !service) return;
+    const center = mapInstance.getCenter()!;
+    findNearbyPlaces(service, { lat: center.lat(), lng: center.lng() }, mapInstance, getTypes(activeCategory));
+    setShowResearchBtn(false);
+  };
+
+  const handleCategoryChange = (category: CategoryKey) => {
+    setActiveCategory(category);
+    if (!mapInstance || !service) return;
+    const center = mapInstance.getCenter()!;
+    findNearbyPlaces(service, { lat: center.lat(), lng: center.lng() }, mapInstance, getTypes(category));
+  };
+
+  return { showResearchBtn, activeCategory, handleResearch, handleCategoryChange };
+};

--- a/client/src/features/googleMap/ui/GoogleMaps.tsx
+++ b/client/src/features/googleMap/ui/GoogleMaps.tsx
@@ -1,30 +1,35 @@
-import React from 'react';
+'use client';
+
 import { useGoogleMap } from '../hooks/useGoogleMap';
+import { useMapControls } from '../hooks/useMapControls';
+import { MapCategoryTabs } from './MapCategoryTabs';
+import { MapCurrentLocationButton } from './MapCurrentLocationButton';
+import { MapLoadingOverlay } from './MapLoadingOverlay';
+import { MapResearchButton } from './MapResearchButton';
 import SearchBar from './SearchBar';
-import { goToCurrentLocation } from '../utils/goToCurrentLocation';
 
 export default function GoogleMaps() {
   const { mapRef, mapInstance, service } = useGoogleMap();
+  const { showResearchBtn, activeCategory, handleResearch, handleCategoryChange } = useMapControls(
+    mapInstance,
+    service,
+  );
 
   return (
     <div className='absolute inset-0'>
-      <SearchBar service={service} mapInstance={mapInstance} />
+      <div className='absolute top-15 left-1/2 z-10 flex w-2/3 -translate-x-1/2 flex-col gap-2 lg:top-5'>
+        <SearchBar service={service} mapInstance={mapInstance} />
+        {mapInstance && (
+          <MapCategoryTabs activeCategory={activeCategory} onChange={handleCategoryChange} />
+        )}
+      </div>
 
-      <button
-        onClick={() => goToCurrentLocation({ mapInstance, service })}
-        className='absolute top-[240px] right-[6px] z-10 rounded-full bg-white p-3 shadow-lg transition hover:bg-gray-100'
-      >
-        📍
-      </button>
+      <MapResearchButton show={showResearchBtn} onClick={handleResearch} />
+      <MapCurrentLocationButton mapInstance={mapInstance} service={service} />
 
       <div ref={mapRef} className='h-full w-full' />
 
-      {!mapInstance && (
-        <div className='absolute inset-0 flex flex-col items-center justify-center gap-3 bg-gray-100'>
-          <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500' />
-          <p className='text-sm text-gray-500'>지도를 불러오는 중...</p>
-        </div>
-      )}
+      {!mapInstance && <MapLoadingOverlay />}
     </div>
   );
 }

--- a/client/src/features/googleMap/ui/MapCategoryTabs.tsx
+++ b/client/src/features/googleMap/ui/MapCategoryTabs.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useTranslation } from '@/src/shared/lib/i18n';
+import type { CategoryKey } from '../hooks/useMapControls';
+
+interface Props {
+  activeCategory: CategoryKey;
+  onChange: (category: CategoryKey) => void;
+}
+
+export function MapCategoryTabs({ activeCategory, onChange }: Props) {
+  const { t } = useTranslation();
+
+  const categories: { key: CategoryKey; label: string }[] = [
+    { key: 'all', label: t('map.category_all') },
+    { key: 'pharmacy', label: t('medical.types.pharmacy') },
+    { key: 'hospital', label: t('medical.types.hospital') },
+  ];
+
+  return (
+    <div className='flex justify-center gap-2'>
+      {categories.map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => onChange(key)}
+          className={`rounded-full px-4 py-1.5 text-sm font-medium shadow-md transition ${
+            activeCategory === key
+              ? 'bg-red-500 text-white'
+              : 'bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/features/googleMap/ui/MapCurrentLocationButton.tsx
+++ b/client/src/features/googleMap/ui/MapCurrentLocationButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { goToCurrentLocation } from '../utils/goToCurrentLocation';
+
+interface Props {
+  mapInstance: google.maps.Map | null;
+  service: google.maps.places.PlacesService | null;
+}
+
+export function MapCurrentLocationButton({ mapInstance, service }: Props) {
+  return (
+    <button
+      onClick={() => goToCurrentLocation({ mapInstance, service })}
+      className='absolute top-[240px] right-[6px] z-10 rounded-full bg-white p-3 shadow-lg transition hover:bg-gray-100'
+    >
+      📍
+    </button>
+  );
+}

--- a/client/src/features/googleMap/ui/MapLoadingOverlay.tsx
+++ b/client/src/features/googleMap/ui/MapLoadingOverlay.tsx
@@ -1,0 +1,8 @@
+export function MapLoadingOverlay() {
+  return (
+    <div className='absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-gray-100'>
+      <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500' />
+      <p className='text-sm text-gray-500'>지도를 불러오는 중...</p>
+    </div>
+  );
+}

--- a/client/src/features/googleMap/ui/MapResearchButton.tsx
+++ b/client/src/features/googleMap/ui/MapResearchButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useTranslation } from '@/src/shared/lib/i18n';
+
+interface Props {
+  show: boolean;
+  onClick: () => void;
+}
+
+export function MapResearchButton({ show, onClick }: Props) {
+  const { t } = useTranslation();
+
+  if (!show) return null;
+
+  return (
+    <button
+      onClick={onClick}
+      className='absolute top-[195px] left-1/2 z-10 -translate-x-1/2 rounded-full bg-white px-5 py-2 text-sm font-medium shadow-lg transition hover:bg-gray-50 lg:top-[145px]'
+    >
+      {t('map.research_area')}
+    </button>
+  );
+}

--- a/client/src/features/googleMap/ui/SearchBar.tsx
+++ b/client/src/features/googleMap/ui/SearchBar.tsx
@@ -20,7 +20,7 @@ export default function SearchBar({
   };
 
   return (
-    <div className='absolute top-15 left-1/2 z-10 w-2/3 -translate-x-1/2 transform rounded-md bg-white p-2 shadow-lg lg:top-5'>
+    <div className='rounded-md bg-white p-2 shadow-lg'>
       <div className='flex'>
         <input
           type='text'

--- a/client/src/features/googleMap/utils/findNearbyPlaces.ts
+++ b/client/src/features/googleMap/utils/findNearbyPlaces.ts
@@ -211,7 +211,7 @@ export const findNearbyPlaces = (
 ) => {
   cleanupNearbyPlaces();
 
-  (window as any).__closeActiveInfoWindow = () => {
+  (window as Window & { __closeActiveInfoWindow?: () => void }).__closeActiveInfoWindow = () => {
     openInfoWindows.forEach((w) => w.close());
     openInfoWindows = [];
   };

--- a/client/src/features/googleMap/utils/findNearbyPlaces.ts
+++ b/client/src/features/googleMap/utils/findNearbyPlaces.ts
@@ -82,10 +82,7 @@ const buildLoadingContent = (): string => `
   </div>
 `;
 
-const buildDetailContent = (
-  place: google.maps.places.PlaceResult,
-  type: string,
-): string => {
+const buildDetailContent = (place: google.maps.places.PlaceResult, type: string): string => {
   const isPharmacy = type === 'pharmacy';
   const accentColor = isPharmacy ? '#10b981' : '#3b82f6';
   const badgeLabel = isPharmacy ? '약국' : '병원';
@@ -292,10 +289,7 @@ export const findNearbyPlaces = (
                 ],
               },
               (detail, detailStatus) => {
-                if (
-                  detailStatus === google.maps.places.PlacesServiceStatus.OK &&
-                  detail
-                ) {
+                if (detailStatus === google.maps.places.PlacesServiceStatus.OK && detail) {
                   detailCache.set(place.place_id!, detail);
                   infoWindow.setContent(buildDetailContent(detail, type));
                 } else {

--- a/client/src/features/googleMap/utils/findNearbyPlaces.ts
+++ b/client/src/features/googleMap/utils/findNearbyPlaces.ts
@@ -1,17 +1,19 @@
 import { MarkerClusterer } from '@googlemaps/markerclusterer';
 
 let activeMarkers: Array<{
-  marker: google.maps.Marker;
+  marker: google.maps.marker.AdvancedMarkerElement;
   listener: google.maps.MapsEventListener;
 }> = [];
 let mapClickListener: google.maps.MapsEventListener | null = null;
 let openInfoWindows: google.maps.InfoWindow[] = [];
 let clusterer: MarkerClusterer | null = null;
+const infoWindowRegistry = new Map<string, google.maps.InfoWindow>();
+const detailCache = new Map<string, google.maps.places.PlaceResult>();
 
 export const cleanupNearbyPlaces = () => {
   activeMarkers.forEach(({ marker, listener }) => {
     google.maps.event.removeListener(listener);
-    marker.setMap(null);
+    marker.map = null;
   });
   activeMarkers = [];
 
@@ -27,18 +29,197 @@ export const cleanupNearbyPlaces = () => {
     clusterer.clearMarkers();
     clusterer = null;
   }
+
+  infoWindowRegistry.clear();
+  detailCache.clear();
+};
+
+const closeBtn = `
+  <button
+    onclick="window.__closeActiveInfoWindow()"
+    style="
+      position:absolute;top:10px;right:10px;
+      background:#f3f4f6;border:none;
+      width:26px;height:26px;border-radius:50%;
+      font-size:13px;color:#6b7280;cursor:pointer;
+      display:flex;align-items:center;justify-content:center;
+      line-height:1;
+    "
+    onmouseover="this.style.background='#e5e7eb'"
+    onmouseout="this.style.background='#f3f4f6'"
+  >&#x2715;</button>
+`;
+
+const renderStars = (rating: number): string => {
+  const full = Math.floor(rating);
+  const half = rating % 1 >= 0.5;
+  const empty = 5 - full - (half ? 1 : 0);
+  return '&#9733;'.repeat(full) + (half ? '&frac12;' : '') + '&#9734;'.repeat(empty);
+};
+
+const buildLoadingContent = (): string => `
+  <div style="
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    width: 260px;
+    padding: 40px 16px 20px;
+    text-align: center;
+    color: #999;
+    font-size: 13px;
+    position: relative;
+    box-sizing: border-box;
+  ">
+    ${closeBtn}
+    <div style="
+      width: 24px; height: 24px;
+      border: 3px solid #e5e7eb;
+      border-top-color: #3b82f6;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto 10px;
+    "></div>
+    불러오는 중...
+    <style>@keyframes spin { to { transform: rotate(360deg); } }</style>
+  </div>
+`;
+
+const buildDetailContent = (
+  place: google.maps.places.PlaceResult,
+  type: string,
+): string => {
+  const isPharmacy = type === 'pharmacy';
+  const accentColor = isPharmacy ? '#10b981' : '#3b82f6';
+  const badgeLabel = isPharmacy ? '약국' : '병원';
+  const badgeBg = isPharmacy ? '#d1fae5' : '#dbeafe';
+  const badgeText = isPharmacy ? '#065f46' : '#1e40af';
+
+  const isOpen = place.opening_hours?.isOpen?.();
+  const openStatus =
+    isOpen === undefined
+      ? ''
+      : isOpen
+        ? `<span style="color:#10b981;font-weight:600;">&#9679; 영업 중</span>`
+        : `<span style="color:#ef4444;font-weight:600;">&#9679; 영업 종료</span>`;
+
+  const rating =
+    place.rating !== undefined
+      ? `<div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">
+           <span style="color:#f59e0b;font-size:14px;letter-spacing:1px;">${renderStars(place.rating)}</span>
+           <span style="font-size:13px;color:#6b7280;">${place.rating.toFixed(1)}</span>
+           ${place.user_ratings_total ? `<span style="font-size:12px;color:#9ca3af;">(${place.user_ratings_total.toLocaleString()})</span>` : ''}
+         </div>`
+      : '';
+
+  const phone = place.formatted_phone_number
+    ? `<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
+         <span style="font-size:15px;">&#128222;</span>
+         <a href="tel:${place.formatted_phone_number}" style="font-size:13px;color:#3b82f6;text-decoration:none;">
+           ${place.formatted_phone_number}
+         </a>
+       </div>`
+    : '';
+
+  const address = place.formatted_address || place.vicinity || '';
+  const addressHtml = address
+    ? `<div style="display:flex;align-items:flex-start;gap:8px;margin-bottom:6px;">
+         <span style="font-size:14px;margin-top:1px;">&#128205;</span>
+         <span style="font-size:12px;color:#6b7280;line-height:1.5;">${address}</span>
+       </div>`
+    : '';
+
+  const website = place.website
+    ? `<a
+         href="${place.website}"
+         target="_blank"
+         rel="noopener noreferrer"
+         style="
+           display:flex;align-items:center;justify-content:center;gap:6px;
+           padding:9px 0;
+           background:#f8fafc;
+           border:1px solid #e2e8f0;
+           border-radius:8px;
+           font-size:13px;color:#374151;text-decoration:none;
+           margin-bottom:8px;
+         "
+         onmouseover="this.style.background='#f1f5f9'"
+         onmouseout="this.style.background='#f8fafc'"
+       >
+         &#127760; 웹사이트 방문
+       </a>`
+    : '';
+
+  return `
+    <div style="
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      width: 260px;
+      padding: 40px 16px 12px;
+      box-sizing: border-box;
+      position: relative;
+    ">
+      ${closeBtn}
+
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+        <span style="
+          display:inline-block;
+          padding:3px 9px;
+          background:${badgeBg};
+          color:${badgeText};
+          font-size:11px;font-weight:700;
+          border-radius:99px;letter-spacing:0.5px;
+        ">${badgeLabel}</span>
+        <span style="font-size:12px;">${openStatus}</span>
+      </div>
+
+      <h2 style="
+        margin:0 0 8px;
+        font-size:16px;font-weight:700;
+        color:#111827;line-height:1.4;
+      ">${place.name}</h2>
+
+      ${rating}
+
+      <div style="border-top:1px solid #f3f4f6;margin:10px 0;"></div>
+
+      ${phone}
+      ${addressHtml}
+
+      <div style="border-top:1px solid #f3f4f6;margin:10px 0;"></div>
+
+      ${website}
+
+      <a
+        href="https://www.google.com/maps/place/?q=place_id:${place.place_id}"
+        target="_blank"
+        rel="noopener noreferrer"
+        style="
+          display:flex;align-items:center;justify-content:center;gap:6px;
+          padding:9px 0;
+          background:${accentColor};
+          border-radius:8px;
+          font-size:13px;color:#fff;font-weight:600;text-decoration:none;
+        "
+        onmouseover="this.style.opacity='0.9'"
+        onmouseout="this.style.opacity='1'"
+      >
+        Google Maps에서 보기 &#8594;
+      </a>
+    </div>
+  `;
 };
 
 export const findNearbyPlaces = (
   placesService: google.maps.places.PlacesService,
   location: google.maps.LatLngLiteral,
   map: google.maps.Map,
+  types: string[] = ['pharmacy', 'hospital'],
 ) => {
   cleanupNearbyPlaces();
 
-  clusterer = new MarkerClusterer({ map, markers: [] });
+  (window as any).__closeActiveInfoWindow = () => {
+    openInfoWindows.forEach((w) => w.close());
+    openInfoWindows = [];
+  };
 
-  const types = ['pharmacy', 'hospital'];
+  clusterer = new MarkerClusterer({ map, markers: [] });
 
   mapClickListener = map.addListener('click', () => {
     openInfoWindows.forEach((w) => w.close());
@@ -55,104 +236,77 @@ export const findNearbyPlaces = (
     placesService.nearbySearch(request, (results, status) => {
       if (status === google.maps.places.PlacesServiceStatus.OK && results) {
         results.forEach((place) => {
-          if (place.geometry?.location) {
-            const marker = new google.maps.Marker({
-              position: place.geometry.location,
-              title: place.name,
-              icon: {
-                url: type === 'pharmacy' ? '/pharmacy-marker.webp' : '/hospital-marker.webp',
-                scaledSize: new google.maps.Size(40, 40),
-              },
-            });
+          if (!place.geometry?.location) return;
 
-            const infoWindow = new google.maps.InfoWindow({
-              content: `
-                  <div style="
-                    font-family: 'Arial', sans-serif;
-                    padding: 18px 14px 28px 12px;
-                    text-align: center;
-                    max-width: 220px;
-                    position: relative;
-                    margin-top: -8px;
-                  ">
-                    <button
-                      onclick="window.__closeInfoWindow && window.__closeInfoWindow(this)"
-                      data-infowindow-id="${place.place_id}"
-                      style="
-                        position: absolute;
-                        top: 8px;
-                        right: 8px;
-                        background: none;
-                        border: none;
-                        font-size: 16px;
-                        color: #666;
-                        cursor: pointer;
-                        padding: 4px 8px;
-                        line-height: 1;
-                        border-radius: 4px;
-                        z-index: 1000;
-                      "
-                      onmouseover="this.style.backgroundColor='#f0f0f0'"
-                      onmouseout="this.style.backgroundColor='transparent'"
-                    >
-                      X
-                    </button>
-                    <h2 style="
-                      font-size: 15px;
-                      margin: 0 0 8px 0;
-                      font-weight: bold;
-                      color: #333;
-                      text-align: center;
-                      word-wrap: break-word;
-                      overflow-wrap: break-word;
-                      max-width: 180px;
-                      margin-left: auto;
-                      margin-right: auto;
-                    ">
-                      ${place.name}
-                    </h2>
-                    <p style="
-                      font-size: 13px;
-                      margin: 0 0 12px 0;
-                      color: #666;
-                    ">
-                      ${place.vicinity || '주소 정보 없음'}
-                    </p>
-                    <a
-                      href="https://www.google.com/maps/place/?q=place_id:${place.place_id}"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style="
-                        display: inline-block;
-                        margin-top: 8px;
-                        padding: 5px 8px;
-                        font-size: 12px;
-                        color: white;
-                        background-color: #4285F4;
-                        text-decoration: none;
-                        border-radius: 4px;
-                      "
-                    >
-                      📍 View on Google Maps
-                    </a>
-                  </div>
-                `,
-            });
+          const markerContent = document.createElement('img');
+          markerContent.src =
+            type === 'pharmacy' ? '/pharmacy-marker.webp' : '/hospital-marker.webp';
+          markerContent.style.width = '40px';
+          markerContent.style.height = '40px';
 
-            infoWindow.addListener('closeclick', () => {
-              openInfoWindows = openInfoWindows.filter((w) => w !== infoWindow);
-            });
+          const marker = new google.maps.marker.AdvancedMarkerElement({
+            position: place.geometry.location,
+            title: place.name,
+            content: markerContent,
+          });
 
-            const clickListener = marker.addListener('click', () => {
-              openInfoWindows.forEach((w) => w.close());
-              openInfoWindows = [];
-              infoWindow.open(map, marker);
-              openInfoWindows.push(infoWindow);
-            });
+          const infoWindow = new google.maps.InfoWindow({
+            content: buildLoadingContent(),
+          });
 
-            clusterer!.addMarker(marker);
-            activeMarkers.push({ marker, listener: clickListener });
+          if (place.place_id) {
+            infoWindowRegistry.set(place.place_id, infoWindow);
           }
+
+          infoWindow.addListener('closeclick', () => {
+            openInfoWindows = openInfoWindows.filter((w) => w !== infoWindow);
+          });
+
+          const clickListener = marker.addListener('click', () => {
+            openInfoWindows.forEach((w) => w.close());
+            openInfoWindows = [];
+            openInfoWindows.push(infoWindow);
+
+            const cached = detailCache.get(place.place_id!);
+            if (cached) {
+              infoWindow.setContent(buildDetailContent(cached, type));
+              infoWindow.open({ map, anchor: marker });
+              return;
+            }
+
+            infoWindow.setContent(buildLoadingContent());
+            infoWindow.open({ map, anchor: marker });
+
+            placesService.getDetails(
+              {
+                placeId: place.place_id!,
+                fields: [
+                  'name',
+                  'formatted_address',
+                  'formatted_phone_number',
+                  'opening_hours',
+                  'rating',
+                  'user_ratings_total',
+                  'website',
+                  'place_id',
+                ],
+              },
+              (detail, detailStatus) => {
+                if (
+                  detailStatus === google.maps.places.PlacesServiceStatus.OK &&
+                  detail
+                ) {
+                  detailCache.set(place.place_id!, detail);
+                  infoWindow.setContent(buildDetailContent(detail, type));
+                } else {
+                  infoWindow.setContent(buildDetailContent(place, type));
+                }
+              },
+            );
+          });
+
+          clusterer!.addMarker(marker);
+          activeMarkers.push({ marker, listener: clickListener });
         });
       } else {
         console.error(`${type} 검색 실패:`, status);

--- a/client/src/features/travelAlert/ui/AlertsPageClient.tsx
+++ b/client/src/features/travelAlert/ui/AlertsPageClient.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTranslation } from '@/src/shared/lib/i18n';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
+import { CountrySearchClient } from './CountrySearchClient';
+
+interface Props {
+  countries: TravelAlertItem[];
+  levelCounts: Record<string, number>;
+}
+
+export const AlertsPageClient = ({ countries, levelCounts }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className='min-h-screen bg-slate-50'>
+      <header className='w-full bg-white shadow-sm'>
+        <div className='mx-auto max-w-5xl px-6 py-5'>
+          <div className='flex items-center gap-3'>
+            <Link href='/' aria-label='VitalTrip'>
+              <Image src='/VitalTrip.svg' alt='VitalTrip' width={40} height={40} className='h-10 w-auto' />
+            </Link>
+            <span className='text-lg font-semibold text-gray-700'>{t('travelAlert.header_title')}</span>
+          </div>
+        </div>
+      </header>
+
+      <main className='mx-auto max-w-5xl px-6 py-10 pb-[100px]'>
+        <div className='mb-8'>
+          <h1 className='text-3xl font-bold text-gray-900'>{t('travelAlert.page_title')}</h1>
+          <p className='mt-2 text-gray-600'>{t('travelAlert.page_description', { count: countries.length })}</p>
+        </div>
+
+        <div className='mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4'>
+          {Object.entries(ALARM_LEVEL).map(([level, { bg, text, border }]) => (
+            <div key={level} className={`rounded-xl border-2 ${border} ${bg} p-4 text-center`}>
+              <div className={`text-2xl font-bold ${text}`}>{levelCounts[level] ?? 0}</div>
+              <div className={`text-sm font-medium ${text}`}>
+                {t('travelAlert.level_count', { level })} · {t(`travelAlert.alarm_levels.${level}`)}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <CountrySearchClient countries={countries} />
+      </main>
+    </div>
+  );
+};

--- a/client/src/features/travelAlert/ui/AlertsPageClient.tsx
+++ b/client/src/features/travelAlert/ui/AlertsPageClient.tsx
@@ -20,9 +20,17 @@ export const AlertsPageClient = ({ countries, levelCounts }: Props) => {
         <div className='mx-auto max-w-5xl px-6 py-5'>
           <div className='flex items-center gap-3'>
             <Link href='/' aria-label='VitalTrip'>
-              <Image src='/VitalTrip.svg' alt='VitalTrip' width={40} height={40} className='h-10 w-auto' />
+              <Image
+                src='/VitalTrip.svg'
+                alt='VitalTrip'
+                width={40}
+                height={40}
+                className='h-10 w-auto'
+              />
             </Link>
-            <span className='text-lg font-semibold text-gray-700'>{t('travelAlert.header_title')}</span>
+            <span className='text-lg font-semibold text-gray-700'>
+              {t('travelAlert.header_title')}
+            </span>
           </div>
         </div>
       </header>
@@ -30,7 +38,9 @@ export const AlertsPageClient = ({ countries, levelCounts }: Props) => {
       <main className='mx-auto max-w-5xl px-6 py-10 pb-[100px]'>
         <div className='mb-8'>
           <h1 className='text-3xl font-bold text-gray-900'>{t('travelAlert.page_title')}</h1>
-          <p className='mt-2 text-gray-600'>{t('travelAlert.page_description', { count: countries.length })}</p>
+          <p className='mt-2 text-gray-600'>
+            {t('travelAlert.page_description', { count: countries.length })}
+          </p>
         </div>
 
         <div className='mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4'>

--- a/client/src/features/travelAlert/ui/CountrySearchClient.tsx
+++ b/client/src/features/travelAlert/ui/CountrySearchClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from '@/src/shared/lib/i18n';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
@@ -11,6 +12,7 @@ interface Props {
 export const CountrySearchClient = ({ countries }: Props) => {
   const [query, setQuery] = useState('');
   const router = useRouter();
+  const { t } = useTranslation();
 
   const deduped = Object.values(
     countries.reduce(
@@ -41,13 +43,13 @@ export const CountrySearchClient = ({ countries }: Props) => {
           type='text'
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder='국가명 검색 (예: 일본, Japan, JP)'
+          placeholder={t('travelAlert.search_placeholder')}
           className='w-full rounded-2xl border border-gray-200 bg-white px-6 py-4 text-lg shadow-lg outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100'
         />
         {query && (
           <button
             onClick={() => setQuery('')}
-            aria-label='검색어 지우기'
+            aria-label={t('common.close')}
             className='absolute top-1/2 right-5 -translate-y-1/2 text-gray-600 hover:text-gray-800'
           >
             ✕
@@ -56,11 +58,13 @@ export const CountrySearchClient = ({ countries }: Props) => {
       </div>
 
       <p className='mb-4 text-sm text-gray-600'>
-        {query ? `"${query}" 검색 결과 ${filtered.length}개` : `전체 ${deduped.length}개국`}
+        {query
+          ? t('travelAlert.search_results', { query, count: filtered.length })
+          : t('travelAlert.total_countries', { count: deduped.length })}
       </p>
 
       {filtered.length === 0 ? (
-        <div className='py-20 text-center text-gray-400'>검색 결과가 없어요</div>
+        <div className='py-20 text-center text-gray-400'>{t('travelAlert.no_results')}</div>
       ) : (
         <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
           {filtered.map((country) => {
@@ -86,7 +90,7 @@ export const CountrySearchClient = ({ countries }: Props) => {
                   <span
                     className={`flex-shrink-0 rounded-full px-2 py-1 text-xs font-bold ${alarmInfo.bg} ${alarmInfo.text}`}
                   >
-                    {country.alarm_lvl}단계
+                    {t('travelAlert.level_label', { level: country.alarm_lvl })}
                   </span>
                 )}
               </button>

--- a/client/src/features/travelAlert/ui/CountrySearchClient.tsx
+++ b/client/src/features/travelAlert/ui/CountrySearchClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslation } from '@/src/shared/lib/i18n';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
@@ -76,10 +77,12 @@ export const CountrySearchClient = ({ countries }: Props) => {
                 className='flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-4 text-left shadow-sm transition-colors transition-shadow duration-200 hover:border-blue-300 hover:bg-blue-50 hover:shadow-md active:bg-blue-100'
               >
                 {country.flag_download_url && (
-                  <img
+                  <Image
                     src={country.flag_download_url}
                     alt={country.country_nm}
-                    className='h-8 w-12 flex-shrink-0 rounded object-cover shadow-sm'
+                    width={48}
+                    height={32}
+                    className='flex-shrink-0 rounded object-cover shadow-sm'
                   />
                 )}
                 <div className='min-w-0 flex-1'>

--- a/client/src/features/travelAlert/ui/TravelAlertContent.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertContent.tsx
@@ -19,7 +19,9 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
           <div className='flex items-center gap-4'>
             <AlarmBadge alarmInfo={alarmInfo} />
             <div>
-              <h2 className={`text-2xl font-bold ${alarmInfo.text}`}>{t(`travelAlert.alarm_levels.${items[0].alarm_lvl}`)}</h2>
+              <h2 className={`text-2xl font-bold ${alarmInfo.text}`}>
+                {t(`travelAlert.alarm_levels.${items[0].alarm_lvl}`)}
+              </h2>
               <p className='mt-1 text-gray-600'>{t('travelAlert.ministry_designation')}</p>
             </div>
           </div>
@@ -30,7 +32,9 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
       <div className='overflow-hidden rounded-2xl bg-white shadow-xl'>
         <div className='bg-gradient-to-r from-slate-700 to-slate-800 px-8 py-6 text-white'>
           <h2 className='text-xl font-bold'>{t('travelAlert.regional_detail_title')}</h2>
-          <p className='mt-1 text-sm text-slate-300'>{t('travelAlert.total_regions', { count: items.length })}</p>
+          <p className='mt-1 text-sm text-slate-300'>
+            {t('travelAlert.total_regions', { count: items.length })}
+          </p>
         </div>
         <div className='divide-y divide-gray-100'>
           {items.map((item, idx) => {
@@ -42,16 +46,21 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
                     <span
                       className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${level.bg} ${level.text}`}
                     >
-                      {t('travelAlert.level_label', { level: item.alarm_lvl })} · {t(`travelAlert.alarm_levels.${item.alarm_lvl}`)}
+                      {t('travelAlert.level_label', { level: item.alarm_lvl })} ·{' '}
+                      {t(`travelAlert.alarm_levels.${item.alarm_lvl}`)}
                     </span>
                   )}
                 </div>
                 <div className='flex-1'>
                   <div className='font-semibold text-gray-900'>
-                    {item.region_ty === '전체' ? t('travelAlert.all_regions') : item.remark || item.region_ty}
+                    {item.region_ty === '전체'
+                      ? t('travelAlert.all_regions')
+                      : item.remark || item.region_ty}
                   </div>
                   {item.written_dt && (
-                    <p className='mt-1 text-sm text-gray-600'>{t('travelAlert.updated_date', { date: item.written_dt })}</p>
+                    <p className='mt-1 text-sm text-gray-600'>
+                      {t('travelAlert.updated_date', { date: item.written_dt })}
+                    </p>
                   )}
                 </div>
               </div>
@@ -120,8 +129,12 @@ const AlarmLevelGuide = () => {
             key={level}
             className={`rounded-xl border-2 ${info.border} ${info.bg} p-4 text-center`}
           >
-            <div className={`text-2xl font-bold ${info.text}`}>{t('travelAlert.level_label', { level })}</div>
-            <div className={`mt-1 text-sm font-semibold ${info.text}`}>{t(`travelAlert.alarm_levels.${level}`)}</div>
+            <div className={`text-2xl font-bold ${info.text}`}>
+              {t('travelAlert.level_label', { level })}
+            </div>
+            <div className={`mt-1 text-sm font-semibold ${info.text}`}>
+              {t(`travelAlert.alarm_levels.${level}`)}
+            </div>
           </div>
         ))}
       </div>

--- a/client/src/features/travelAlert/ui/TravelAlertContent.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslation } from '@/src/shared/lib/i18n';
+import Image from 'next/image';
 import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
 
 interface Props {
@@ -76,10 +77,13 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
             <h2 className='text-xl font-bold'>{t('travelAlert.danger_map')}</h2>
           </div>
           <div className='p-6'>
-            <img
+            <Image
               src={items[0].dang_map_download_url}
               alt={t('travelAlert.danger_map')}
-              className='w-full rounded-xl object-contain'
+              width={0}
+              height={0}
+              sizes="100vw"
+              className='h-auto w-full rounded-xl object-contain'
             />
           </div>
         </div>

--- a/client/src/features/travelAlert/ui/TravelAlertContent.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertContent.tsx
@@ -82,7 +82,7 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
               alt={t('travelAlert.danger_map')}
               width={0}
               height={0}
-              sizes="100vw"
+              sizes='100vw'
               className='h-auto w-full rounded-xl object-contain'
             />
           </div>

--- a/client/src/features/travelAlert/ui/TravelAlertContent.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertContent.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from '@/src/shared/lib/i18n';
 import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
 
 interface Props {
@@ -8,6 +9,8 @@ interface Props {
 }
 
 export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
+  const { t } = useTranslation();
+
   return (
     <div className='space-y-6'>
       {/* 경보단계 배너 */}
@@ -16,8 +19,8 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
           <div className='flex items-center gap-4'>
             <AlarmBadge alarmInfo={alarmInfo} />
             <div>
-              <h2 className={`text-2xl font-bold ${alarmInfo.text}`}>{alarmInfo.label}</h2>
-              <p className='mt-1 text-gray-600'>외교부 지정 여행경보 단계</p>
+              <h2 className={`text-2xl font-bold ${alarmInfo.text}`}>{t(`travelAlert.alarm_levels.${items[0].alarm_lvl}`)}</h2>
+              <p className='mt-1 text-gray-600'>{t('travelAlert.ministry_designation')}</p>
             </div>
           </div>
         </div>
@@ -26,8 +29,8 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
       {/* 경보 상세 목록 */}
       <div className='overflow-hidden rounded-2xl bg-white shadow-xl'>
         <div className='bg-gradient-to-r from-slate-700 to-slate-800 px-8 py-6 text-white'>
-          <h2 className='text-xl font-bold'>지역별 경보 상세</h2>
-          <p className='mt-1 text-sm text-slate-300'>총 {items.length}개 지역</p>
+          <h2 className='text-xl font-bold'>{t('travelAlert.regional_detail_title')}</h2>
+          <p className='mt-1 text-sm text-slate-300'>{t('travelAlert.total_regions', { count: items.length })}</p>
         </div>
         <div className='divide-y divide-gray-100'>
           {items.map((item, idx) => {
@@ -39,16 +42,16 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
                     <span
                       className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${level.bg} ${level.text}`}
                     >
-                      {item.alarm_lvl}단계 · {level.label}
+                      {t('travelAlert.level_label', { level: item.alarm_lvl })} · {t(`travelAlert.alarm_levels.${item.alarm_lvl}`)}
                     </span>
                   )}
                 </div>
                 <div className='flex-1'>
                   <div className='font-semibold text-gray-900'>
-                    {item.region_ty === '전체' ? '전 지역' : item.remark || item.region_ty}
+                    {item.region_ty === '전체' ? t('travelAlert.all_regions') : item.remark || item.region_ty}
                   </div>
                   {item.written_dt && (
-                    <p className='mt-1 text-sm text-gray-600'>갱신일: {item.written_dt}</p>
+                    <p className='mt-1 text-sm text-gray-600'>{t('travelAlert.updated_date', { date: item.written_dt })}</p>
                   )}
                 </div>
               </div>
@@ -61,12 +64,12 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
       {items[0]?.dang_map_download_url && (
         <div className='overflow-hidden rounded-2xl bg-white shadow-xl'>
           <div className='bg-gradient-to-r from-slate-700 to-slate-800 px-8 py-6 text-white'>
-            <h2 className='text-xl font-bold'>위험지도</h2>
+            <h2 className='text-xl font-bold'>{t('travelAlert.danger_map')}</h2>
           </div>
           <div className='p-6'>
             <img
               src={items[0].dang_map_download_url}
-              alt='위험지도'
+              alt={t('travelAlert.danger_map')}
               className='w-full rounded-xl object-contain'
             />
           </div>
@@ -78,7 +81,7 @@ export const TravelAlertContent = ({ items, alarmInfo }: Props) => {
 
       {/* 출처 */}
       <p className='text-center text-sm text-gray-600'>
-        출처: 외교부 해외안전여행 (
+        {t('travelAlert.source')} (
         <a
           href='https://www.0404.go.kr'
           target='_blank'
@@ -104,21 +107,24 @@ const AlarmBadge = ({
   );
 };
 
-const AlarmLevelGuide = () => (
-  <div className='overflow-hidden rounded-2xl bg-white shadow-xl'>
-    <div className='bg-gradient-to-r from-slate-700 to-slate-800 px-8 py-6 text-white'>
-      <h2 className='text-xl font-bold'>여행경보 단계 안내</h2>
+const AlarmLevelGuide = () => {
+  const { t } = useTranslation();
+  return (
+    <div className='overflow-hidden rounded-2xl bg-white shadow-xl'>
+      <div className='bg-gradient-to-r from-slate-700 to-slate-800 px-8 py-6 text-white'>
+        <h2 className='text-xl font-bold'>{t('travelAlert.alert_level_guide')}</h2>
+      </div>
+      <div className='grid grid-cols-2 gap-4 p-6 sm:grid-cols-4'>
+        {Object.entries(ALARM_LEVEL).map(([level, info]) => (
+          <div
+            key={level}
+            className={`rounded-xl border-2 ${info.border} ${info.bg} p-4 text-center`}
+          >
+            <div className={`text-2xl font-bold ${info.text}`}>{t('travelAlert.level_label', { level })}</div>
+            <div className={`mt-1 text-sm font-semibold ${info.text}`}>{t(`travelAlert.alarm_levels.${level}`)}</div>
+          </div>
+        ))}
+      </div>
     </div>
-    <div className='grid grid-cols-2 gap-4 p-6 sm:grid-cols-4'>
-      {Object.entries(ALARM_LEVEL).map(([level, info]) => (
-        <div
-          key={level}
-          className={`rounded-xl border-2 ${info.border} ${info.bg} p-4 text-center`}
-        >
-          <div className={`text-2xl font-bold ${info.text}`}>{level}단계</div>
-          <div className={`mt-1 text-sm font-semibold ${info.text}`}>{info.label}</div>
-        </div>
-      ))}
-    </div>
-  </div>
-);
+  );
+};

--- a/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
@@ -40,10 +40,12 @@ export const TravelAlertCountryClient = ({ items }: Props) => {
         <div className='mb-8 overflow-hidden rounded-2xl bg-white shadow-xl'>
           <div className='flex items-center gap-6 p-8'>
             {country.flag_download_url && (
-              <img
+              <Image
                 src={country.flag_download_url}
                 alt={`${country.country_eng_nm} flag`}
-                className='h-16 w-24 rounded-lg object-cover shadow-md'
+                width={96}
+                height={64}
+                className='rounded-lg object-cover shadow-md'
               />
             )}
             <div>

--- a/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
@@ -21,9 +21,17 @@ export const TravelAlertCountryClient = ({ items }: Props) => {
         <div className='mx-auto max-w-4xl px-6 py-5'>
           <div className='flex items-center gap-3'>
             <Link href='/' aria-label='VitalTrip'>
-              <Image src='/VitalTrip.svg' alt='VitalTrip' width={40} height={40} className='h-10 w-auto' />
+              <Image
+                src='/VitalTrip.svg'
+                alt='VitalTrip'
+                width={40}
+                height={40}
+                className='h-10 w-auto'
+              />
             </Link>
-            <span className='text-lg font-semibold text-gray-700'>{t('travelAlert.header_title')}</span>
+            <span className='text-lg font-semibold text-gray-700'>
+              {t('travelAlert.header_title')}
+            </span>
           </div>
         </div>
       </header>

--- a/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
+++ b/client/src/features/travelAlert/ui/TravelAlertCountryClient.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useTranslation } from '@/src/shared/lib/i18n';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ALARM_LEVEL, TravelAlertItem } from '../types/travelAlert';
+import { TravelAlertContent } from './TravelAlertContent';
+
+interface Props {
+  items: TravelAlertItem[];
+}
+
+export const TravelAlertCountryClient = ({ items }: Props) => {
+  const { t } = useTranslation();
+  const country = items[0];
+  const alarmInfo = ALARM_LEVEL[country.alarm_lvl as keyof typeof ALARM_LEVEL];
+
+  return (
+    <div className='min-h-screen bg-slate-50'>
+      <header className='w-full bg-white shadow-sm'>
+        <div className='mx-auto max-w-4xl px-6 py-5'>
+          <div className='flex items-center gap-3'>
+            <Link href='/' aria-label='VitalTrip'>
+              <Image src='/VitalTrip.svg' alt='VitalTrip' width={40} height={40} className='h-10 w-auto' />
+            </Link>
+            <span className='text-lg font-semibold text-gray-700'>{t('travelAlert.header_title')}</span>
+          </div>
+        </div>
+      </header>
+
+      <main className='mx-auto max-w-4xl px-6 py-10 pb-[100px]'>
+        <div className='mb-8 overflow-hidden rounded-2xl bg-white shadow-xl'>
+          <div className='flex items-center gap-6 p-8'>
+            {country.flag_download_url && (
+              <img
+                src={country.flag_download_url}
+                alt={`${country.country_eng_nm} flag`}
+                className='h-16 w-24 rounded-lg object-cover shadow-md'
+              />
+            )}
+            <div>
+              <p className='text-sm text-gray-600'>{country.continent_eng_nm}</p>
+              <h1 className='text-3xl font-bold text-gray-900'>{country.country_eng_nm}</h1>
+              <p className='text-lg text-gray-600'>{country.country_nm}</p>
+            </div>
+          </div>
+        </div>
+
+        <TravelAlertContent items={items} alarmInfo={alarmInfo} />
+      </main>
+    </div>
+  );
+};

--- a/client/src/shared/hooks/useLanguageSelection.tsx
+++ b/client/src/shared/hooks/useLanguageSelection.tsx
@@ -22,13 +22,12 @@ export const useLanguageSelection = () => {
     }
   }, [overlay]);
 
-  const selectLanguage = (languageCode: string) => {
-    i18n.changeLanguage(languageCode).then(() => {
-      window.dispatchEvent(new Event('languageChanged'));
-    });
+  const selectLanguage = async (languageCode: string) => {
     localStorage.setItem('user-set-language', 'true');
     setHasLanguagePreference(true);
     overlay.close();
+    await i18n.loadLanguages(languageCode);
+    await i18n.changeLanguage(languageCode);
   };
 
   return {

--- a/client/src/shared/providers/I18nProvider.tsx
+++ b/client/src/shared/providers/I18nProvider.tsx
@@ -4,10 +4,6 @@ import { i18n } from '@/src/shared/lib/i18n';
 import { ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 
-interface I18nProviderProps {
-  children: ReactNode;
-}
-
-export const I18nProvider = ({ children }: I18nProviderProps) => {
+export const I18nProvider = ({ children }: { children: ReactNode }) => {
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 };

--- a/client/src/widgets/bottomNavigateBar/ui/LanguageSwitcher.tsx
+++ b/client/src/widgets/bottomNavigateBar/ui/LanguageSwitcher.tsx
@@ -10,8 +10,9 @@ const languages = [
 export const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
 
-  const changeLanguage = (lng: string) => {
-    i18n.changeLanguage(lng);
+  const changeLanguage = async (lng: string) => {
+    await i18n.loadLanguages(lng);
+    await i18n.changeLanguage(lng);
   };
 
   return (

--- a/client/src/widgets/navbar/Navbar.tsx
+++ b/client/src/widgets/navbar/Navbar.tsx
@@ -7,12 +7,12 @@ import { useProfileQuery } from '@/src/features/profile/api/useProfileQuery';
 import { useHydration } from '@/src/shared/hooks/useHydration';
 import { useTranslation } from '@/src/shared/lib/i18n';
 import Dropdown from '@/src/shared/ui/Dropdown';
+import { FaBars, FaChevronDown, FaTimes } from '@/src/shared/ui/icons';
 import { AnimatePresence, motion } from 'motion/react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { FaBars, FaChevronDown, FaTimes } from '@/src/shared/ui/icons';
 
 const LanguageDropdown = () => {
   const { i18n } = useTranslation();
@@ -38,14 +38,14 @@ const LanguageDropdown = () => {
 
   const currentLanguage = languages.find((lang) => lang.code === currentLang) || languages[0];
 
-  const handleLanguageChange = (langCode: string) => {
+  const handleLanguageChange = async (langCode: string) => {
+    setIsOpen(false);
     if (pathname.startsWith('/about')) {
       router.push(`/about/${langCode}`);
-      i18n.changeLanguage(langCode);
-    } else {
-      i18n.changeLanguage(langCode);
+      return;
     }
-    setIsOpen(false);
+    await i18n.loadLanguages(langCode);
+    await i18n.changeLanguage(langCode);
   };
 
   const displayLanguage = isHydrated ? currentLanguage : languages[0];
@@ -89,8 +89,18 @@ const LanguageDropdown = () => {
   );
 };
 
-export default function Navbar() {
-  const { t } = useTranslation();
+type NavTranslations = {
+  home: string;
+  about: string;
+  news: string;
+  translate: string;
+  first_aid: string;
+  hospital_pharmacy_nearby: string;
+};
+
+export default function Navbar({ navTranslations }: { navTranslations?: NavTranslations }) {
+  const { t: i18nT } = useTranslation();
+  const t = (key: keyof NavTranslations) => navTranslations?.[key] ?? i18nT(`navbar.${key}`);
 
   const { data: isLoggedIn } = useCheckIfLoggedInQuery();
   const { data: profile } = useProfileQuery();
@@ -129,31 +139,31 @@ export default function Navbar() {
               href='/'
               className='flex items-center space-x-1 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
             >
-              <span>{t('navbar.home')}</span>
+              <span>{t('home')}</span>
             </Link>
             <Link
               href='/about'
               className='flex items-center space-x-1 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
             >
-              <span>{t('navbar.about')}</span>
+              <span>{t('about')}</span>
             </Link>
             <Link
               href='/news/1'
               className='flex items-center space-x-1 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
             >
-              <span>{t('navbar.news')}</span>
+              <span>{t('news')}</span>
             </Link>
             <Link
               href='/translate'
               className='flex items-center space-x-1 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
             >
-              <span>{t('navbar.translate')}</span>
+              <span>{t('translate')}</span>
             </Link>
             <Link
               href='/first-aid'
               className='flex items-center space-x-1 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
             >
-              <span>{t('navbar.first_aid')}</span>
+              <span>{t('first_aid')}</span>
             </Link>
           </div>
 
@@ -198,35 +208,35 @@ export default function Navbar() {
                   onClick={closeMenu}
                   className='flex items-center justify-center space-x-2 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
                 >
-                  <span>{t('navbar.hospital_pharmacy_nearby')}</span>
+                  <span>{t('hospital_pharmacy_nearby')}</span>
                 </Link>
                 <Link
                   href='/about'
                   onClick={closeMenu}
                   className='flex items-center justify-center space-x-2 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
                 >
-                  <span>{t('navbar.about')}</span>
+                  <span>{t('about')}</span>
                 </Link>
                 <Link
                   href='/news/1'
                   onClick={closeMenu}
                   className='flex items-center justify-center space-x-2 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
                 >
-                  <span>{t('navbar.news')}</span>
+                  <span>{t('news')}</span>
                 </Link>
                 <Link
                   href='/translate'
                   onClick={closeMenu}
                   className='flex items-center justify-center space-x-2 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
                 >
-                  <span>{t('navbar.translate')}</span>
+                  <span>{t('translate')}</span>
                 </Link>
                 <Link
                   href='/first-aid'
                   onClick={closeMenu}
                   className='flex items-center justify-center space-x-2 rounded-md px-3 py-2 text-gray-700 transition-colors duration-200 hover:bg-blue-50 hover:text-blue-600'
                 >
-                  <span>{t('navbar.first_aid')}</span>
+                  <span>{t('first_aid')}</span>
                 </Link>
                 <div className='flex items-center justify-center gap-4'>
                   <LanguageDropdown />


### PR DESCRIPTION
## Summary

### 1. Google Maps 기능 개선 (closes #90)
- **카테고리 탭 추가**: 병원/약국/응급실 카테고리별 필터링 (`MapCategoryTabs`)
- **재검색 버튼**: 지도 이동 후 "이 지역 재검색" 버튼으로 현재 영역 재조회 (`MapResearchButton`)
- **현재 위치 버튼**: 지도 위 floating 현재 위치 이동 버튼 분리 (`MapCurrentLocationButton`)
- **검색 로직 자동화**: 버튼 없이 카테고리 변경 시 자동 검색, `useMapControls` 훅으로 지도 상태 관리 분리
- **로딩 오버레이**: 검색 중 지도 위 로딩 UI 분리 (`MapLoadingOverlay`)

### 2. 여행경보 페이지 리팩토링
- `alerts/page.tsx`, `alerts/[countryCode]/page.tsx`에서 인라인 JSX 제거
- `AlertsPageClient`, `TravelAlertCountryClient`로 클라이언트 컴포넌트 분리
- 메타데이터 영문 통일

### 3. i18n 번역 추가
- `map.category_all`, `map.research_area` 번역 추가 (지도 UI용)
- `travelAlert.*` 번역 전체 추가 — 경보 단계, 검색 결과 등 (en/ko)

### 4. About SSG 페이지 Navbar 번역 키 flash 수정

**문제**: `/about/en` 새로고침 또는 언어 전환 시 Navbar 링크가 `navbar.home`, `navbar.about` 등 dot notation 키로 0.1초간 노출

**원인 분석**:
- `/about/[lang]`은 `force-static` SSG 페이지로 URL이 언어의 source of truth
- 그러나 `<Navbar />`는 i18next HTTP backend로 번역을 비동기 fetch → hydration 시점에 미로드
- 언어 전환 시 `i18n.changeLanguage` → `router.push` 순서로 React 렌더링 도중 i18n 전환 상태 충돌

**해결**:
- `aboutTranslations`에 `navbar` 항목 추가 (SSG 번역 객체에 포함)
- `Navbar`에 `navTranslations?: NavTranslations` prop 추가 — prop이 있으면 i18n 없이 즉시 렌더링
- SSG 페이지에서 `<Navbar navTranslations={translations.navbar} />` 로 주입
- `handleLanguageChange`: about 페이지에서 `i18n.changeLanguage` 제거, `router.push`만 실행
- `useLanguageSelection`의 리스너 없는 `window.dispatchEvent('languageChanged')` dead code 제거
- `LanguageSwitcher`: `changeLanguage` 전 `loadLanguages` 선행 호출로 번역 미로드 flash 방지

## Test plan
- [ ] `/about/en` 새로고침 시 Navbar 링크 즉시 영문 표시 (flash 없음)
- [ ] `/about/en` → 한국어 전환 → `/about/ko` 이동, Navbar 즉시 한국어 표시
- [ ] 홈 페이지에서 언어 전환 정상 작동
- [ ] 지도 카테고리 탭 전환 시 자동 검색
- [ ] 지도 이동 후 재검색 버튼 노출 및 동작
- [ ] 여행경보 목록/상세 페이지 정상 렌더링

Closes #90