### PR TITLE
[FEAT] Apple 로그인 구현 

### DIFF
--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { LoginForm } from '@/src/features/auth';
+import { AppleAuthButton } from '@/src/features/auth/ui/AppleAuthButton';
 import { GoogleAuthButton } from '@/src/features/auth/ui/GoogleAuthButton';
 import { Metadata } from 'next';
 import Image from 'next/image';
@@ -30,6 +31,7 @@ export default function LoginPage() {
         <div className='flex flex-col gap-4 rounded-xl bg-white px-8 py-10 shadow-lg'>
           <LoginForm />
           <GoogleAuthButton />
+          <AppleAuthButton />
           <div className='mt-6 text-center'>
             <div className='relative'>
               <div className='absolute inset-0 flex items-center'>

--- a/client/src/features/auth/api/loginApple.ts
+++ b/client/src/features/auth/api/loginApple.ts
@@ -1,0 +1,14 @@
+import { httpClient } from '@/src/shared/utils/httpClient';
+
+interface AppleLoginPayload {
+  identityToken: string;
+  fullName?: {
+    givenName?: string;
+    familyName?: string;
+  };
+  email?: string;
+}
+
+export const loginApple = async (payload: AppleLoginPayload): Promise<void> => {
+  await httpClient.post('/api/auth/apple', payload);
+};

--- a/client/src/features/auth/ui/AppleAuthButton.tsx
+++ b/client/src/features/auth/ui/AppleAuthButton.tsx
@@ -63,7 +63,13 @@ export const AppleAuthButton = () => {
       onClick={handleAppleAuthClick}
       className='flex w-full items-center justify-center gap-2 rounded-md bg-black p-3 font-semibold text-white shadow-sm transition-colors duration-300 hover:bg-gray-900'
     >
-      <svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 814 1000' fill='white'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='20'
+        height='20'
+        viewBox='0 0 814 1000'
+        fill='white'
+      >
         <path d='M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-57.8-155.5-127.4C46 790.7 0 663 0 541.8c0-207.5 135.4-317.3 268.5-317.3 65 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z' />
       </svg>
       Sign in with Apple

--- a/client/src/features/auth/ui/AppleAuthButton.tsx
+++ b/client/src/features/auth/ui/AppleAuthButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useIsWebView } from '@/src/shared/hooks/useIsWebView';
+import { APIError } from '@/src/shared/utils/apiError';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { loginApple } from '../api/loginApple';
+
+declare global {
+  interface Window {
+    handleAppleSignInResult?: (
+      identityToken: string,
+      fullName: { givenName?: string; familyName?: string } | null,
+      email: string | null,
+    ) => void;
+    webkit?: {
+      messageHandlers?: {
+        appleSignIn?: {
+          postMessage: (message: object) => void;
+        };
+      };
+    };
+  }
+}
+
+export const AppleAuthButton = () => {
+  const isWebView = useIsWebView();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    window.handleAppleSignInResult = async (identityToken, fullName, email) => {
+      try {
+        await loginApple({
+          identityToken,
+          fullName: fullName ?? undefined,
+          email: email ?? undefined,
+        });
+        queryClient.invalidateQueries({ queryKey: ['auth', 'isLoggedIn'] });
+        queryClient.invalidateQueries({ queryKey: ['profile'] });
+        router.push('/');
+      } catch (error) {
+        if (error instanceof APIError) {
+          console.error('Apple login error:', error.message, error.status);
+        }
+      }
+    };
+
+    return () => {
+      window.handleAppleSignInResult = undefined;
+    };
+  }, [router, queryClient]);
+
+  if (!isWebView) return null;
+
+  const handleAppleAuthClick = () => {
+    window.webkit?.messageHandlers?.appleSignIn?.postMessage({});
+  };
+
+  return (
+    <button
+      onClick={handleAppleAuthClick}
+      className='flex w-full items-center justify-center gap-2 rounded-md bg-black p-3 font-semibold text-white shadow-sm transition-colors duration-300 hover:bg-gray-900'
+    >
+      <svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 814 1000' fill='white'>
+        <path d='M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-57.8-155.5-127.4C46 790.7 0 663 0 541.8c0-207.5 135.4-317.3 268.5-317.3 65 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z' />
+      </svg>
+      Sign in with Apple
+    </button>
+  );
+};

--- a/client/src/features/auth/ui/GoogleAuthButton.tsx
+++ b/client/src/features/auth/ui/GoogleAuthButton.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useIsWebView } from '@/src/shared/hooks/useIsWebView';
 import { APIError } from '@/src/shared/utils/apiError';
 import Image from 'next/image';
 import { loginGoogle } from '../api/loginGoogle';
 
 export const GoogleAuthButton = () => {
+  const isWebView = useIsWebView();
+
   const handleGoogleAuthClick = async () => {
     try {
       await loginGoogle();
@@ -14,6 +17,8 @@ export const GoogleAuthButton = () => {
       }
     }
   };
+
+  if (!isWebView) return null;
 
   return (
     <button

--- a/client/src/shared/hooks/useIsWebView.ts
+++ b/client/src/shared/hooks/useIsWebView.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export const useIsWebView = (): boolean => {
+  const [isWebView, setIsWebView] = useState(false);
+
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    setIsWebView(/VitalTrip/i.test(ua) || !!window.webkit?.messageHandlers);
+  }, []);
+
+  return isWebView;
+};


### PR DESCRIPTION
## 개요
Apple 로그인 기능을 구현하고, Google/Apple OAuth 버튼을 WebView 환경에서만 노출합니다.

## 변경 사항
- `useIsWebView`: UA 또는 `window.webkit.messageHandlers` 기반 WebView 감지 훅
- `loginApple`: BFF `/api/auth/apple`로 identityToken 전달하는 API 함수
- `AppleAuthButton`: iOS WebView 브릿지(`window.webkit.messageHandlers.appleSignIn`)로 네이티브 Apple Sign In 트리거
- `GoogleAuthButton`: WebView 환경에서만 렌더링되도록 수정
- `login/page.tsx`: AppleAuthButton 추가

## 관련 이슈
closes #112