### PR TITLE
[FEAT] 웹뷰 구글 로그인 지원

### DIFF
--- a/app/components/VitalTripWebView.tsx
+++ b/app/components/VitalTripWebView.tsx
@@ -1,4 +1,5 @@
 import * as AppleAuthentication from 'expo-apple-authentication';
+import * as WebBrowser from 'expo-web-browser';
 import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -167,6 +168,24 @@ export default function VitalTripWebView() {
     return () => handler.remove();
   }, []);
 
+  const handleGoogleSignIn = async () => {
+    const result = await WebBrowser.openAuthSessionAsync(
+      `${WEB_URL}/api/auth/loginGoogle?source=native`,
+      'vitaltrip://',
+    );
+    if (result.type === 'success') {
+      const url = new URL(result.url);
+      const needsProfile = url.searchParams.get('needsProfile');
+      if (needsProfile) {
+        webViewRef.current?.injectJavaScript(
+          `window.location.href = '${WEB_URL}/signup?step=step2'; true;`,
+        );
+      } else {
+        webViewRef.current?.reload();
+      }
+    }
+  };
+
   const handleAppleSignIn = async () => {
     try {
       const credential = await AppleAuthentication.signInAsync({
@@ -236,6 +255,10 @@ export default function VitalTripWebView() {
 
       if (data.type === 'APPLE_SIGN_IN') {
         handleAppleSignIn();
+      }
+
+      if (data.type === 'GOOGLE_SIGN_IN') {
+        handleGoogleSignIn();
       }
     } catch {}
   };

--- a/client/app/api/auth/loginGoogle/route.ts
+++ b/client/app/api/auth/loginGoogle/route.ts
@@ -1,7 +1,7 @@
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpServer } from '@/src/shared/utils/httpServer';
 import * as Sentry from '@sentry/nextjs';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 interface LoginGoogleResponse {
   message: string;
@@ -11,12 +11,23 @@ interface LoginGoogleResponse {
   };
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const response: LoginGoogleResponse = await httpServer.get('/oauth2/login-url');
     const googleLoginUrl = response.data.googleLoginUrl;
 
-    return NextResponse.redirect(googleLoginUrl);
+    const redirectResponse = NextResponse.redirect(googleLoginUrl);
+
+    if (new URL(request.url).searchParams.get('source') === 'native') {
+      redirectResponse.cookies.set('auth_source', 'native', {
+        maxAge: 300,
+        path: '/',
+        sameSite: 'lax',
+        secure: true,
+      });
+    }
+
+    return redirectResponse;
   } catch (error) {
     Sentry.captureException(error);
     return NextResponse.json(

--- a/client/app/auth/callback/page.tsx
+++ b/client/app/auth/callback/page.tsx
@@ -6,6 +6,15 @@ import { setToSessionStorage } from '@/src/shared/utils/sessionService';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+const isNativeSource = () => {
+  const match = document.cookie.split(';').find((c) => c.trim().startsWith('auth_source='));
+  return match?.split('=')?.[1]?.trim() === 'native';
+};
+
+const clearNativeSourceCookie = () => {
+  document.cookie = 'auth_source=; Max-Age=0; Path=/';
+};
+
 export default function OAuthCallbackPage() {
   const router = useRouter();
 
@@ -32,6 +41,11 @@ export default function OAuthCallbackPage() {
           const googleProfile = await oAuthCallback();
           setToSessionStorage('google-profile', JSON.stringify(googleProfile));
           window.history.replaceState({}, document.title, window.location.pathname);
+          if (isNativeSource()) {
+            clearNativeSourceCookie();
+            window.location.href = 'vitaltrip://auth-complete';
+            return;
+          }
           router.push('/');
           return;
         }
@@ -40,6 +54,11 @@ export default function OAuthCallbackPage() {
           const googleProfile = await oAuthCallback();
           setToSessionStorage('google-profile', JSON.stringify(googleProfile));
           window.history.replaceState({}, document.title, window.location.pathname);
+          if (isNativeSource()) {
+            clearNativeSourceCookie();
+            window.location.href = 'vitaltrip://auth-complete?needsProfile=true';
+            return;
+          }
           router.push('/signup?step=step2');
           return;
         }
@@ -47,6 +66,11 @@ export default function OAuthCallbackPage() {
         const googleProfile = await oAuthCallback();
         setToSessionStorage('google-profile', JSON.stringify(googleProfile));
         window.history.replaceState({}, document.title, window.location.pathname);
+        if (isNativeSource()) {
+          clearNativeSourceCookie();
+          window.location.href = 'vitaltrip://auth-complete?needsProfile=true';
+          return;
+        }
         router.push('/signup?step=step2');
       } catch (error) {
         if (error instanceof APIError) {

--- a/client/src/features/auth/api/loginGoogle.ts
+++ b/client/src/features/auth/api/loginGoogle.ts
@@ -1,7 +1,13 @@
-export const loginGoogle = async () => {
-  try {
+declare global {
+  interface Window {
+    ReactNativeWebView?: { postMessage: (msg: string) => void };
+  }
+}
+
+export const loginGoogle = () => {
+  if (window.ReactNativeWebView) {
+    window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'GOOGLE_SIGN_IN' }));
+  } else {
     window.location.href = '/api/auth/loginGoogle';
-  } catch (error) {
-    throw error;
   }
 };


### PR DESCRIPTION
## Summary
- `loginGoogle.ts`: WebView 환경 감지 후 `postMessage(GOOGLE_SIGN_IN)`으로 네이티브 브릿지 분기
- `VitalTripWebView.tsx`: `openAuthSessionAsync`로 외부 브라우저에서 Google OAuth 처리 후 딥링크 콜백 수신
- `loginGoogle/route.ts`: `source=native` 감지 시 `auth_source=native` 쿠키 세팅
- `callback/page.tsx`: `isNativeSource()` 체크 후 `vitaltrip://` 딥링크로 리디렉션 (success / needsProfile / fallback 세 케이스 모두 처리)

## Test plan
- [ ] 앱 WebView에서 구글 로그인 버튼 클릭 시 외부 브라우저(ASWebAuthenticationSession) 열림
- [ ] 계정 선택 후 앱으로 복귀 및 세션 정상 설정 확인
- [ ] needsProfile 케이스: `/signup?step=step2`로 이동 확인
- [ ] 웹 브라우저에서 기존 구글 로그인 플로우 정상 동작 확인 (회귀 없음)