### PR TITLE
[FIX] 웹뷰 구글 로그인 재이동 버그 수정

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -12,6 +12,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.vitaltrip.app",
       "buildNumber": "1",
+      "usesAppleSignIn": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocationWhenInUseUsageDescription": "VitalTrip uses your location to find nearby hospitals and emergency services.",

--- a/app/components/VitalTripWebView.tsx
+++ b/app/components/VitalTripWebView.tsx
@@ -117,15 +117,11 @@ export default function VitalTripWebView() {
       'vitaltrip://',
     );
     if (result.type === 'success') {
-      const url = new URL(result.url);
-      const needsProfile = url.searchParams.get('needsProfile');
-      if (needsProfile) {
-        webViewRef.current?.injectJavaScript(
-          `window.location.href = '${WEB_URL}/signup?step=step2'; true;`,
-        );
-      } else {
-        webViewRef.current?.reload();
-      }
+      const deepLink = new URL(result.url);
+      const params = deepLink.search;
+      webViewRef.current?.injectJavaScript(
+        `window.location.href = '${WEB_URL}/auth/callback${params}'; true;`,
+      );
     }
   };
 

--- a/client/app/auth/callback/page.tsx
+++ b/client/app/auth/callback/page.tsx
@@ -37,15 +37,16 @@ export default function OAuthCallbackPage() {
           return;
         }
 
+        if (isNativeSource()) {
+          clearNativeSourceCookie();
+          window.location.href = `vitaltrip://auth-complete${window.location.search}`;
+          return;
+        }
+
         if (success) {
           const googleProfile = await oAuthCallback();
           setToSessionStorage('google-profile', JSON.stringify(googleProfile));
           window.history.replaceState({}, document.title, window.location.pathname);
-          if (isNativeSource()) {
-            clearNativeSourceCookie();
-            window.location.href = 'vitaltrip://auth-complete';
-            return;
-          }
           router.push('/');
           return;
         }
@@ -54,11 +55,6 @@ export default function OAuthCallbackPage() {
           const googleProfile = await oAuthCallback();
           setToSessionStorage('google-profile', JSON.stringify(googleProfile));
           window.history.replaceState({}, document.title, window.location.pathname);
-          if (isNativeSource()) {
-            clearNativeSourceCookie();
-            window.location.href = 'vitaltrip://auth-complete?needsProfile=true';
-            return;
-          }
           router.push('/signup?step=step2');
           return;
         }
@@ -66,11 +62,6 @@ export default function OAuthCallbackPage() {
         const googleProfile = await oAuthCallback();
         setToSessionStorage('google-profile', JSON.stringify(googleProfile));
         window.history.replaceState({}, document.title, window.location.pathname);
-        if (isNativeSource()) {
-          clearNativeSourceCookie();
-          window.location.href = 'vitaltrip://auth-complete?needsProfile=true';
-          return;
-        }
         router.push('/signup?step=step2');
       } catch (error) {
         if (error instanceof APIError) {

--- a/client/src/features/auth/ui/AuthButton.tsx
+++ b/client/src/features/auth/ui/AuthButton.tsx
@@ -10,7 +10,7 @@ interface AuthButtonProps {
 export const AuthButton = ({ closeMenu, mobileHidden }: AuthButtonProps) => {
   const { data: isAuthenticated } = useCheckIfLoggedInQuery();
 
-  const mobileHiddenClass = mobileHidden ? 'hidden md:flex' : '';
+  const mobileHiddenClass = mobileHidden ? 'hidden md:flex' : 'flex';
 
   const { mutateAsync: logoutUser } = useLogoutMutation();
 
@@ -34,7 +34,7 @@ export const AuthButton = ({ closeMenu, mobileHidden }: AuthButtonProps) => {
     <Link
       href='/login'
       onClick={closeMenu}
-      className={`${mobileHiddenClass} items-center justify-center rounded-md bg-blue-600 px-3 py-2 font-semibold text-white transition-colors duration-200 hover:bg-blue-700 md:flex`}
+      className={`${mobileHiddenClass} items-center justify-center rounded-md bg-blue-600 px-3 py-2 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
     >
       LOGIN
     </Link>

--- a/client/src/features/profile/ui/UserProfileInfo.tsx
+++ b/client/src/features/profile/ui/UserProfileInfo.tsx
@@ -181,19 +181,33 @@ const ProfileLoading = () => {
 
 const ProfileError = ({ onClose }: { onClose?: () => void }) => {
   return (
-    <div className='flex min-h-[400px] items-center justify-center'>
-      <div className='rounded-lg bg-red-50 p-6 text-center'>
-        <div className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100'>
-          <MdError className='h-6 w-6 text-red-600' />
-        </div>
-        <div className='mb-2 text-lg font-medium text-red-800'>Unable to load profile</div>
-        <div className='mt-4 text-sm text-gray-500'>Please log in to set up your profile.</div>
-        <AuthButton closeMenu={onClose} />
-
-        <span className='mt-2 text-sm text-gray-500'>
-          If the problem persists, please contact customer support.
-        </span>
+    <motion.div
+      className='mx-auto w-[320px] max-w-2xl px-3 py-8 md:w-[500px]'
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+    >
+      <div className='mb-8 text-center'>
+        <h1 className='mb-2 text-3xl font-bold text-gray-900'>Profile</h1>
       </div>
-    </div>
+      <div className='overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-lg'>
+        <div className='bg-gradient-to-r from-blue-500 to-purple-600 px-6 py-10 text-center text-white'>
+          <div className='mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full border-4 border-white bg-white/20'>
+            <MdPerson className='h-10 w-10 text-white' />
+          </div>
+          <h2 className='mb-1 text-2xl font-bold'>Guest</h2>
+          <p className='text-sm text-blue-100'>Please log in to view your profile</p>
+        </div>
+        <div className='flex flex-col items-center gap-4 p-8 text-center'>
+          <p className='text-sm leading-relaxed text-gray-500'>
+            Sign in to access your profile and personalize your experience.
+          </p>
+          <AuthButton closeMenu={onClose} />
+          <p className='text-xs text-gray-400'>
+            If the problem persists, please contact customer support.
+          </p>
+        </div>
+      </div>
+    </motion.div>
   );
 };

--- a/client/src/features/profile/ui/UserProfileInfo.tsx
+++ b/client/src/features/profile/ui/UserProfileInfo.tsx
@@ -1,12 +1,6 @@
 import { motion } from 'motion/react';
 import Image from 'next/image';
-import {
-  MdCalendarToday,
-  MdEmail,
-  MdFlag,
-  MdPerson,
-  MdPhone,
-} from '@/src/shared/ui/icons';
+import { MdCalendarToday, MdEmail, MdFlag, MdPerson, MdPhone } from '@/src/shared/ui/icons';
 import { useCheckIfLoggedInQuery } from '../../auth/api/checkIfLoggedIn';
 import { AuthButton } from '../../auth/ui/AuthButton';
 import { useProfileQuery } from '../api/useProfileQuery';

--- a/client/src/features/profile/ui/UserProfileInfo.tsx
+++ b/client/src/features/profile/ui/UserProfileInfo.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import {
   MdCalendarToday,
   MdEmail,
-  MdError,
   MdFlag,
   MdPerson,
   MdPhone,


### PR DESCRIPTION
## 원인
`oAuthCallback()`(쿠키 세팅 fetch)이 ASWebAuthenticationSession(외부 브라우저) 안에서 실행되어, `accessToken`/`refreshToken` 쿠키가 WebView가 아닌 외부 브라우저 쿠키 스토어에 저장됨. 이후 WebView를 `reload()` 해도 쿠키가 없어 서버가 미인증으로 판단 → 로그인 페이지로 리다이렉트.

Apple 로그인은 fetch가 WebView 안에서 직접 실행되어 정상 동작.

## 수정
- `callback/page.tsx`: native 환경이면 `oAuthCallback()` 호출 없이 원본 쿼리 파라미터를 딥링크로 포워딩
- `VitalTripWebView.tsx`: 딥링크 수신 후 `reload()` 대신 WebView를 `/auth/callback?<params>`로 이동 → WebView 컨텍스트에서 `oAuthCallback()` 실행 → 쿠키가 WebView에 직접 저장
- `app.json` ios 설정에 `usesAppleSignIn: true` 추가 → Apple Sign In 엔티틀먼트 누락으로 인증 실패 수정

## Test plan
- [ ] 웹뷰에서 구글 로그인 후 홈으로 정상 이동 확인
- [ ] needsProfile 케이스: `/signup?step=step2`로 이동 확인
- [ ] 웹 브라우저 구글 로그인 정상 동작 확인 (회귀 없음)
- [ ] Apple 로그인 정상 동작 확인 (회귀 없음)