### PR TITLE
[FEAT] Apple 신규 유저 프로필 입력 플로우 구현

### DIFF
--- a/app/components/VitalTripWebView.tsx
+++ b/app/components/VitalTripWebView.tsx
@@ -154,7 +154,12 @@ export default function VitalTripWebView() {
         })
           .then(function(res) { return res.json(); })
           .then(function(data) {
-            if (data.success) window.location.href = '/';
+            if (data.success && data.isNewUser) {
+              sessionStorage.setItem('apple-profile', JSON.stringify({ email: ${email} }));
+              window.location.href = '/signup?step=step2';
+            } else if (data.success) {
+              window.location.href = '/';
+            }
           })
           .catch(console.error);
         true;

--- a/client/app/api/auth/apple/route.ts
+++ b/client/app/api/auth/apple/route.ts
@@ -27,6 +27,7 @@ interface AppleLoginResponse {
   data: {
     accessToken: string;
     refreshToken: string;
+    isNewUser: boolean;
   };
 }
 
@@ -108,7 +109,7 @@ export async function POST(req: NextRequest) {
     const { accessToken, refreshToken } = response.data;
 
     const res = NextResponse.json(
-      { success: true, message: 'Apple login successful' },
+      { success: true, isNewUser: response.data.isNewUser, message: 'Apple login successful' },
       { status: 200 },
     );
 

--- a/client/app/api/users/profile/route.ts
+++ b/client/app/api/users/profile/route.ts
@@ -1,0 +1,24 @@
+import { APIError } from '@/src/shared/utils/apiError';
+import { httpServer } from '@/src/shared/utils/httpServer';
+import * as Sentry from '@sentry/nextjs';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const accessToken = req.cookies.get('accessToken')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+    await httpServer.patch('/users/profile', body, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return NextResponse.json({ message: 'Profile updated' }, { status: 200 });
+  } catch (error) {
+    Sentry.captureException(error);
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : 'Profile update failed' },
+      { status: error instanceof APIError ? error.status : 500 },
+    );
+  }
+}

--- a/client/src/features/auth/api/useCompleteAppleProfileMutation.ts
+++ b/client/src/features/auth/api/useCompleteAppleProfileMutation.ts
@@ -1,0 +1,32 @@
+import { APIError } from '@/src/shared/utils/apiError';
+import { httpClient } from '@/src/shared/utils/httpClient';
+import { removeFromSessionStorage } from '@/src/shared/utils/sessionService';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+interface AppleProfileFormData {
+  name: string;
+  birthDate: string;
+  countryCode: string;
+  phoneNumber: string;
+}
+
+export const useCompleteAppleProfileMutation = () => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: completeAppleProfile,
+    onSuccess: () => {
+      removeFromSessionStorage('apple-profile');
+      router.push('/');
+    },
+    onError: (error) => {
+      if (error instanceof APIError) {
+        console.error('Profile update failed:', error.message);
+      }
+    },
+  });
+};
+
+const completeAppleProfile = async (profile: AppleProfileFormData) => {
+  return await httpClient.patch('/api/users/profile', profile);
+};

--- a/client/src/features/auth/hooks/useSignup.ts
+++ b/client/src/features/auth/hooks/useSignup.ts
@@ -1,5 +1,6 @@
 import { APIError } from '@/src/shared/utils/apiError';
 import { useState } from 'react';
+import { useCompleteAppleProfileMutation } from '../api/useCompleteAppleProfileMutation';
 import { useSignupGoogleMutation } from '../api/useSignupGoogleMutation';
 import { useSignupMutation } from '../api/useSignupMutation';
 import type { SignupErrors, SignupForm } from '../types/signup';
@@ -32,6 +33,11 @@ export const useSignup = () => {
     isPending: isGooglePending,
     error: signupGoogleError,
   } = useSignupGoogleMutation();
+  const {
+    mutateAsync: completeAppleProfile,
+    isPending: isApplePending,
+    error: appleError,
+  } = useCompleteAppleProfileMutation();
 
   const handleFormChange = (field: keyof SignupForm, value: string) => {
     if (field === 'email') {
@@ -70,16 +76,18 @@ export const useSignup = () => {
     }));
   };
 
-  const handleSubmit = async (isGoogleSignup?: boolean) => {
+  const handleSubmit = async (provider?: 'google' | 'apple') => {
     try {
-      if (isGoogleSignup) {
-        const googleFormData = {
-          name: signupForm.name,
-          birthDate: signupForm.birthDate,
-          countryCode: signupForm.countryCode,
-          phoneNumber: signupForm.phoneNumber,
-        };
-        await signupGoogleUser(googleFormData);
+      const profileData = {
+        name: signupForm.name,
+        birthDate: signupForm.birthDate,
+        countryCode: signupForm.countryCode,
+        phoneNumber: signupForm.phoneNumber,
+      };
+      if (provider === 'apple') {
+        await completeAppleProfile(profileData);
+      } else if (provider === 'google') {
+        await signupGoogleUser(profileData);
       } else {
         await signupUser(signupForm);
       }
@@ -109,8 +117,8 @@ export const useSignup = () => {
 
   return {
     signupForm,
-    isLoading: isPending || isGooglePending,
-    error: signupError || signupGoogleError,
+    isLoading: isPending || isGooglePending || isApplePending,
+    error: signupError || signupGoogleError || appleError,
     handleFormChange,
     handleSubmit,
     isFirstStepValid,

--- a/client/src/widgets/signup/Signup3.tsx
+++ b/client/src/widgets/signup/Signup3.tsx
@@ -15,27 +15,35 @@ interface FormData {
 interface Signup3Props {
   formData: FormData;
   onPrev: () => void;
-  onSubmit: (isGoogleSignup?: boolean) => void;
+  onSubmit: (provider?: 'google' | 'apple') => void;
   isLoading: boolean;
 }
 
 export default function Signup3({ formData, onPrev, onSubmit, isLoading }: Signup3Props) {
   let googleEmail: string | undefined;
+  let isAppleAuth = false;
+  let appleEmail: string | undefined;
 
   try {
     const googleProfile = getFromSessionStorage('google-profile');
     googleEmail = googleProfile?.email;
-  } catch {
-    googleEmail = undefined;
-  }
+  } catch {}
+
+  try {
+    const appleProfile = getFromSessionStorage('apple-profile');
+    isAppleAuth = true;
+    appleEmail = appleProfile?.email ?? undefined;
+  } catch {}
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (googleEmail) {
-      onSubmit(true);
-      return;
+    if (isAppleAuth) {
+      onSubmit('apple');
+    } else if (googleEmail) {
+      onSubmit('google');
+    } else {
+      onSubmit();
     }
-    onSubmit();
   };
 
   return (
@@ -50,7 +58,7 @@ export default function Signup3({ formData, onPrev, onSubmit, isLoading }: Signu
           </div>
           <div>
             <span className='text-sm font-medium text-gray-600'>Email:</span>
-            <p className='text-gray-800'>{googleEmail || formData.email}</p>
+            <p className='text-gray-800'>{googleEmail || appleEmail || formData.email}</p>
           </div>
           <div>
             <span className='text-sm font-medium text-gray-600'>Date of Birth:</span>


### PR DESCRIPTION
## Summary
- Apple 로그인 신규 유저가 추가 정보(`birthDate`, `phoneNumber`, `countryCode`) 없이 홈으로 이동하던 문제 수정
- `isNewUser: true`이면 `/signup?step=step2`로 redirect하여 프로필 입력 후 `PATCH /users/profile`로 업데이트
- Google 로그인 signup 플로우를 재사용하여 `provider` 분기(`google` / `apple` / 일반)로 통합

Closes #116

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `VitalTripWebView.tsx` | `isNewUser` 분기 — 신규이면 sessionStorage 저장 후 signup redirect |
| `app/api/auth/apple/route.ts` | `isNewUser` 응답 클라이언트에 전달 |
| `app/api/users/profile/route.ts` | 프로필 업데이트 PATCH 엔드포인트 신규 추가 |
| `useCompleteAppleProfileMutation.ts` | Apple 프로필 완성 mutation 신규 추가 |
| `useSignup.ts` | `provider` 파라미터로 google/apple/일반 가입 분기 통합 |
| `Signup3.tsx` | `apple-profile` sessionStorage 감지하여 Apple 분기 처리 |

## Flow
```
Apple 로그인 (신규)
  → isNewUser: true
  → sessionStorage에 apple-profile 저장
  → /signup?step=step2 redirect
  → Signup2 (profile 입력) → Signup3 (confirm)
  → PATCH /api/users/profile
  → apple-profile sessionStorage 정리 → / redirect
```

## Test plan
- [ ] Apple 로그인 신규 유저 → `/signup?step=step2`로 이동하는지 확인
- [ ] 프로필 입력 완료 후 홈으로 이동하는지 확인
- [ ] Apple 로그인 기존 유저 → 홈으로 바로 이동하는지 확인
- [ ] 프로필 입력 도중 나갔다가 재로그인 시 동작 확인 (현재 `isNewUser` 기준이므로 재진입 안 됨 — 추후 `needsProfile`로 개선 예정)