### PR TITLE
[TEST] Playwright E2E 테스트 및 CI 자동화 구축 (#120)

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -54,6 +54,63 @@ jobs:
       - name: Build application
         run: pnpm --filter client build
 
+  e2e:
+    runs-on: ubuntu-latest
+    name: E2E Tests
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm --filter client run generate
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vitaltrip
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter client exec playwright install chromium --with-deps
+
+      - name: Install Chromium system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter client exec playwright install-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm --filter client test:e2e
+        env:
+          CI: true
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vitaltrip
+          NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: dummy_maps_key_for_ci
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: client/playwright-report/
+          retention-days: 7
+
   security-check:
     runs-on: ubuntu-latest
     name: Security Check

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/client/e2e/auth.spec.ts
+++ b/client/e2e/auth.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs } from './helpers/mock';
+
+test.describe('인증 플로우', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+  });
+
+  test('로그인 페이지 렌더링', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page).toHaveTitle(/Login.*VitalTrip/i);
+    // 로그인 페이지에 VitalTrip Logo 이미지가 있음 (LanguageSelectionModal에도 동일 alt가 있어 .first() 사용)
+    await expect(page.locator('img[alt="VitalTrip Logo"]').first()).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toContainText('Login');
+  });
+
+  test('로그인 - 빈 폼 제출 시 버튼 비활성화', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.locator('button[type="submit"]')).toBeDisabled();
+  });
+
+  test('로그인 - 잘못된 자격증명 에러 표시', async ({ page }) => {
+    await page.goto('/login');
+
+    // 패스워드 정책(소문자+숫자+특수문자 조합)을 만족해야 버튼이 활성화됨
+    await page.fill('#email', 'wrong@example.com');
+    await page.fill('#password', 'WrongPass1!');
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('p.text-red-600').first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('로그인 페이지 - 회원가입 링크 클릭', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.click('a[href="/signup"]');
+    await expect(page).toHaveURL('/signup');
+  });
+
+  test('회원가입 페이지 렌더링', async ({ page }) => {
+    await page.goto('/signup');
+
+    await expect(page).toHaveTitle(/Sign Up.*VitalTrip/i);
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.locator('#passwordConfirm')).toBeVisible();
+  });
+
+  test('회원가입 - 비밀번호 불일치 시 Continue 버튼 비활성화', async ({ page }) => {
+    await page.goto('/signup');
+
+    await page.fill('#email', 'test@example.com');
+    await page.fill('#password', 'Password1!');
+    await page.fill('#passwordConfirm', 'DifferentPass1!');
+
+    await expect(page.locator('button[type="submit"]')).toBeDisabled();
+  });
+
+  test('회원가입 - 로그인 페이지 이동 링크', async ({ page }) => {
+    await page.goto('/signup');
+
+    await page.click('a[href="/login"]');
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('회원가입 - step1 정상 입력 시 Continue 활성화', async ({ page }) => {
+    await page.goto('/signup');
+
+    await page.fill('#email', 'newuser@example.com');
+    await page.fill('#password', 'Password1!');
+    await page.fill('#passwordConfirm', 'Password1!');
+
+    await expect(page.locator('button[type="submit"]')).toBeEnabled({ timeout: 5_000 });
+  });
+});

--- a/client/e2e/encyclopedia.spec.ts
+++ b/client/e2e/encyclopedia.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { setupPage, mockAuthAPIs, mockEncyclopediaAPI, MOCK_ENCYCLOPEDIA_ITEMS } from './helpers/mock';
+import {
+  setupPage,
+  mockAuthAPIs,
+  mockEncyclopediaAPI,
+  MOCK_ENCYCLOPEDIA_ITEMS,
+} from './helpers/mock';
 
 test.describe('응급 사전 (Encyclopedia)', () => {
   test.beforeEach(async ({ page }) => {

--- a/client/e2e/encyclopedia.spec.ts
+++ b/client/e2e/encyclopedia.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs, mockEncyclopediaAPI, MOCK_ENCYCLOPEDIA_ITEMS } from './helpers/mock';
+
+test.describe('응급 사전 (Encyclopedia)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await mockEncyclopediaAPI(page);
+    await page.goto('/encyclopedia');
+  });
+
+  test('페이지 타이틀', async ({ page }) => {
+    await expect(page).toHaveTitle(/응급 사전.*Vital Trip/i);
+  });
+
+  test('검색 input 렌더링', async ({ page }) => {
+    await expect(page.locator('input').first()).toBeVisible();
+  });
+
+  test('검색어 입력 시 /api/encyclopedia 호출', async ({ page }) => {
+    const searchInput = page.locator('input').first();
+
+    const [request] = await Promise.all([
+      page.waitForRequest('**/api/encyclopedia**'),
+      searchInput.fill('fever'),
+    ]);
+
+    expect(request.url()).toContain('search=fever');
+  });
+
+  test('검색 결과로 mock 데이터 렌더링', async ({ page }) => {
+    const searchInput = page.locator('input').first();
+    await searchInput.fill('fever');
+
+    // 디바운스(300ms) + 렌더링 대기
+    await page.waitForTimeout(500);
+
+    await expect(page.getByText(MOCK_ENCYCLOPEDIA_ITEMS[0].title)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('검색어 지우기', async ({ page }) => {
+    const searchInput = page.locator('input').first();
+    await searchInput.fill('test');
+    await page.waitForTimeout(400);
+    await searchInput.clear();
+    await expect(searchInput).toHaveValue('');
+  });
+
+  test('카테고리 버튼이 여러 개 렌더링', async ({ page }) => {
+    const buttons = page.locator('button');
+    await expect(buttons.first()).toBeVisible();
+    expect(await buttons.count()).toBeGreaterThan(1);
+  });
+
+  test('검색 후 여러 mock 아이템 표시', async ({ page }) => {
+    const searchInput = page.locator('input').first();
+    await searchInput.fill('a');
+    await page.waitForTimeout(500);
+
+    // mock 응답의 모든 아이템이 표시됨
+    for (const item of MOCK_ENCYCLOPEDIA_ITEMS) {
+      await expect(page.getByText(item.title)).toBeVisible({ timeout: 5_000 });
+    }
+  });
+});

--- a/client/e2e/first-aid.spec.ts
+++ b/client/e2e/first-aid.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs } from './helpers/mock';
+
+test.describe('AI 응급처치 (First Aid)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await page.goto('/first-aid');
+  });
+
+  test('헤더 및 타이틀 표시', async ({ page }) => {
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('h1')).toContainText('AI First Aid');
+  });
+
+  test('VitalTrip 로고 클릭 - 홈으로 이동', async ({ page }) => {
+    await page.locator('header a[href="/"]').click();
+    await expect(page).toHaveURL('/');
+  });
+
+  test('페이지 레이아웃 렌더링', async ({ page }) => {
+    // div.min-h-screen이 여러 개일 수 있으므로 .first() 사용
+    await expect(page.locator('div.min-h-screen').first()).toBeVisible();
+  });
+
+  test('인터랙션 가능한 요소 존재', async ({ page }) => {
+    const interactiveElements = page.locator('button, input, textarea');
+    expect(await interactiveElements.count()).toBeGreaterThan(0);
+  });
+});

--- a/client/e2e/helpers/mock.ts
+++ b/client/e2e/helpers/mock.ts
@@ -1,0 +1,90 @@
+import { Page } from '@playwright/test';
+
+// LanguageSelectionModal은 localStorage에 'user-set-language'가 없으면
+// portal backdrop을 열어 모든 클릭을 차단함. page.goto() 전에 반드시 호출.
+export async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('user-set-language', 'true');
+  });
+}
+
+export const MOCK_ENCYCLOPEDIA_ITEMS = [
+  {
+    id: 1,
+    title: 'Fever',
+    altTitles: ['Pyrexia', 'High temperature'],
+    summary: 'A temporary increase in body temperature, often caused by an illness.',
+    categories: ['infectious'],
+    url: '',
+  },
+  {
+    id: 2,
+    title: 'Headache',
+    altTitles: ['Cephalgia'],
+    summary: 'Pain or discomfort in the head, scalp, or neck.',
+    categories: ['neurological'],
+    url: '',
+  },
+  {
+    id: 3,
+    title: 'Fracture',
+    altTitles: ['Broken bone'],
+    summary: 'A crack or complete break in a bone.',
+    categories: ['injury'],
+    url: '',
+  },
+];
+
+export const MOCK_LANGUAGES = [
+  { language: 'en', name: 'English' },
+  { language: 'ko', name: 'Korean' },
+  { language: 'ja', name: 'Japanese' },
+  { language: 'zh', name: 'Chinese (Simplified)' },
+  { language: 'es', name: 'Spanish' },
+];
+
+export async function mockAuthAPIs(page: Page) {
+  await page.route('**/api/auth/isLoggedIn', (route) =>
+    route.fulfill({ json: { isLoggedIn: false } }),
+  );
+
+  await page.route('**/api/auth/login', (route) =>
+    route.fulfill({
+      status: 401,
+      json: { message: 'The email or password is incorrect' },
+    }),
+  );
+
+  await page.route('**/api/auth/check-email**', (route) =>
+    route.fulfill({ json: { available: true } }),
+  );
+
+  await page.route('**/api/auth/signup', (route) =>
+    route.fulfill({ status: 201, json: { message: 'Signup success' } }),
+  );
+}
+
+export async function mockEncyclopediaAPI(page: Page) {
+  await page.route('**/api/encyclopedia**', (route) =>
+    route.fulfill({
+      json: {
+        message: 'success',
+        data: {
+          total: MOCK_ENCYCLOPEDIA_ITEMS.length,
+          items: MOCK_ENCYCLOPEDIA_ITEMS,
+        },
+      },
+    }),
+  );
+}
+
+export async function mockTranslateAPI(page: Page) {
+  await page.route('**/api/translate', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ json: MOCK_LANGUAGES });
+    }
+    return route.fulfill({
+      json: { translatedText: '두통이 있습니다', detectedSourceLanguage: 'en' },
+    });
+  });
+}

--- a/client/e2e/navigation.spec.ts
+++ b/client/e2e/navigation.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs, mockEncyclopediaAPI } from './helpers/mock';
+
+test.describe('네비게이션', () => {
+  test('홈 페이지 접근', async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+  });
+
+  test('Navbar 렌더링 (encyclopedia 페이지)', async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await mockEncyclopediaAPI(page);
+    await page.goto('/encyclopedia');
+
+    await expect(page.locator('nav')).toBeVisible();
+    await expect(page.locator('nav a[href="/"]').first()).toBeVisible();
+  });
+
+  test('Navbar - Translate 링크 이동', async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await mockEncyclopediaAPI(page);
+    await page.goto('/encyclopedia');
+
+    await page.locator('nav a[href="/translate"]').click();
+    await expect(page).toHaveURL('/translate');
+  });
+
+  test('Navbar - First Aid 링크 이동', async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await mockEncyclopediaAPI(page);
+    await page.goto('/encyclopedia');
+
+    await page.locator('nav a[href="/first-aid"]').click();
+    await expect(page).toHaveURL('/first-aid');
+  });
+
+  test('로그인 페이지 로고 클릭 - 홈으로 이동', async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await page.goto('/login');
+
+    await page.locator('a[href="/"] img[alt="VitalTrip Logo"]').first().click();
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/client/e2e/translate.spec.ts
+++ b/client/e2e/translate.spec.ts
@@ -27,7 +27,10 @@ test.describe('AI 번역 (Translate)', () => {
     const textarea = page.locator('textarea').first();
     await textarea.fill('I have a headache');
 
-    const translateBtn = page.locator('button').filter({ hasText: /translate|번역/i }).first();
+    const translateBtn = page
+      .locator('button')
+      .filter({ hasText: /translate|번역/i })
+      .first();
     if (await translateBtn.isVisible()) {
       const [request] = await Promise.all([
         page.waitForRequest(
@@ -43,7 +46,10 @@ test.describe('AI 번역 (Translate)', () => {
     const textarea = page.locator('textarea').first();
     await textarea.fill('I have a headache');
 
-    const translateBtn = page.locator('button').filter({ hasText: /translate|번역/i }).first();
+    const translateBtn = page
+      .locator('button')
+      .filter({ hasText: /translate|번역/i })
+      .first();
     if (await translateBtn.isVisible()) {
       await translateBtn.click();
       await expect(page.getByText('두통이 있습니다')).toBeVisible({ timeout: 5_000 });

--- a/client/e2e/translate.spec.ts
+++ b/client/e2e/translate.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs, mockTranslateAPI } from './helpers/mock';
+
+test.describe('AI 번역 (Translate)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await mockTranslateAPI(page);
+    await page.goto('/translate');
+  });
+
+  test('페이지 렌더링', async ({ page }) => {
+    await expect(page.locator('main')).toBeVisible();
+  });
+
+  test('소스 텍스트 입력 영역 존재', async ({ page }) => {
+    await expect(page.locator('textarea').first()).toBeVisible();
+  });
+
+  test('텍스트 입력', async ({ page }) => {
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('I have a headache and fever');
+    await expect(textarea).toHaveValue('I have a headache and fever');
+  });
+
+  test('번역 버튼 클릭 시 /api/translate POST 호출', async ({ page }) => {
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('I have a headache');
+
+    const translateBtn = page.locator('button').filter({ hasText: /translate|번역/i }).first();
+    if (await translateBtn.isVisible()) {
+      const [request] = await Promise.all([
+        page.waitForRequest(
+          (req) => req.url().includes('/api/translate') && req.method() === 'POST',
+        ),
+        translateBtn.click(),
+      ]);
+      expect(request.postDataJSON()).toMatchObject({ text: 'I have a headache' });
+    }
+  });
+
+  test('번역 결과 표시 (mock 응답)', async ({ page }) => {
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('I have a headache');
+
+    const translateBtn = page.locator('button').filter({ hasText: /translate|번역/i }).first();
+    if (await translateBtn.isVisible()) {
+      await translateBtn.click();
+      await expect(page.getByText('두통이 있습니다')).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test('언어 목록 GET /api/translate 호출', async ({ page }) => {
+    // 페이지 로드 시 언어 목록을 가져오는 요청 발생
+    const langRequest = page.waitForRequest(
+      (req) => req.url().includes('/api/translate') && req.method() === 'GET',
+    );
+    await page.goto('/translate');
+    await expect(langRequest).resolves.toBeTruthy();
+  });
+});

--- a/client/e2e/travel-alerts.spec.ts
+++ b/client/e2e/travel-alerts.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, mockAuthAPIs } from './helpers/mock';
+
+// /alerts 페이지는 SSR에서 공공 API를 직접 호출함.
+// API 키 없는 환경에서는 빈 배열([])로 폴백되므로 UI 구조 테스트에 집중.
+test.describe('해외여행 경보 (Travel Alerts)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await mockAuthAPIs(page);
+    await page.goto('/alerts');
+  });
+
+  test('페이지 타이틀', async ({ page }) => {
+    await expect(page).toHaveTitle(/Travel Alert.*VitalTrip/i);
+  });
+
+  test('VitalTrip 로고 표시', async ({ page }) => {
+    await expect(page.locator('img[alt="VitalTrip"]').first()).toBeVisible();
+  });
+
+  test('경보 레벨 통계 섹션 렌더링', async ({ page }) => {
+    const statsGrid = page.locator('main .grid').first();
+    await expect(statsGrid).toBeVisible();
+  });
+
+  test('국가 검색 input 렌더링', async ({ page }) => {
+    const searchInput = page.locator('input').first();
+    if (await searchInput.isVisible()) {
+      await searchInput.fill('Korea');
+      await page.waitForTimeout(300);
+      await expect(page.locator('body')).toBeVisible();
+    }
+  });
+
+  test('VitalTrip 로고 클릭 - 홈으로 이동', async ({ page }) => {
+    await page.locator('header a[href="/"]').click();
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
     "ci": "pnpm type-check && pnpm lint && pnpm format:check && pnpm build"
   },
   "dependencies": {
@@ -58,6 +61,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@types/google.maps": "^3.58.1",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
         version: 2.6.2
       '@next/third-parties':
         specifier: ^15.4.5
-        version: 15.4.5(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 15.4.5(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@prisma/adapter-pg':
         specifier: ^7.2.0
         version: 7.2.0
@@ -238,7 +238,7 @@ importers:
         version: 7.2.0(prisma@7.2.0(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3))(typescript@5.8.3)
       '@sentry/nextjs':
         specifier: ^10.0.0
-        version: 10.0.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.101.0)
+        version: 10.0.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.101.0)
       '@tailwindcss/postcss':
         specifier: ^4.1.11
         version: 4.1.11
@@ -271,7 +271,7 @@ importers:
         version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next:
         specifier: '>=16.2.6'
-        version: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pg:
         specifier: ^8.17.1
         version: 8.17.1
@@ -297,6 +297,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.6.4
@@ -1728,6 +1731,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/adapter-pg@7.2.0':
     resolution: {integrity: sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==}
@@ -4445,6 +4453,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5923,6 +5936,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -8810,9 +8833,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@15.4.5(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+  '@next/third-parties@15.4.5(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
     dependencies:
-      next: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       third-party-capital: 1.0.20
 
@@ -9085,6 +9108,10 @@ snapshots:
   '@oxc-project/types@0.124.0': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@prisma/adapter-pg@7.2.0':
     dependencies:
@@ -9812,7 +9839,7 @@ snapshots:
 
   '@sentry/core@10.0.0': {}
 
-  '@sentry/nextjs@10.0.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.101.0)':
+  '@sentry/nextjs@10.0.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.101.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.36.0
@@ -9825,7 +9852,7 @@ snapshots:
       '@sentry/vercel-edge': 10.0.0
       '@sentry/webpack-plugin': 4.0.2(webpack@5.101.0)
       chalk: 3.0.0
-      next: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -12279,6 +12306,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13835,7 +13865,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -13855,6 +13885,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -14127,6 +14158,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

- 핵심 사용자 시나리오 35개 E2E 테스트 구현 (auth, navigation, encyclopedia, translate, travel-alerts, first-aid)
- `page.route()` 기반 API 모킹으로 백엔드 없이 실행 가능
- GitHub Actions CI에 E2E job 추가 (기존 job과 병렬 실행, Chromium 브라우저 캐시 적용)

## 주요 변경 파일

| 파일 | 설명 |
|---|---|
| `client/e2e/**` | 시나리오별 스펙 파일 + mock 헬퍼 |
| `client/playwright.config.ts` | Playwright 설정 (webServer 포함) |
| `.github/workflows/client-ci.yml` | E2E CI job 추가 |

## 기술적 결정

- **LanguageSelectionModal 우회**: `localStorage`에 `user-set-language` 미설정 시 portal backdrop이 모든 클릭을 차단 → `page.addInitScript()`로 페이지 로드 전 사전 주입
- **SSR vs CSR 모킹**: `/alerts`, `/encyclopedia` 초기 데이터는 서버사이드 fetch라 `page.route()` 우회 불가 → 클라이언트 사이드 API(`/api/encyclopedia?search=...`)만 모킹, SSR은 서비스 내 try/catch 폴백 활용
- **패스워드 정책 준수**: 로그인 에러 테스트에서 `validatePassword` 정규식(소문자+숫자+특수문자) 충족 필요 → `WrongPass1!` 사용

## Test plan

- [x] `pnpm test:e2e` 로컬 실행 — 35/35 통과
- [ ] PR CI에서 E2E job 통과 확인

Closes #120