### PR TITLE
[FEAT] useSyncExternalStore 기반 토스트 알림 시스템 구현

### DIFF
--- a/client/app/auth/callback/page.tsx
+++ b/client/app/auth/callback/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { oAuthCallback } from '@/src/features/auth/api/oAuthCallback';
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { setToSessionStorage } from '@/src/shared/utils/sessionService';
 import { useRouter } from 'next/navigation';
@@ -47,6 +48,7 @@ export default function OAuthCallbackPage() {
           const googleProfile = await oAuthCallback();
           setToSessionStorage('google-profile', JSON.stringify(googleProfile));
           window.history.replaceState({}, document.title, window.location.pathname);
+          toast.success('Logged in with Google successfully.');
           router.push('/');
           return;
         }

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -10,6 +10,7 @@ import StructuredData, {
   organizationStructuredData,
   websiteStructuredData,
 } from '@/src/shared/ui/StructuredData';
+import { ToastContainer } from '@/src/shared/ui/ToastContainer';
 import ConditionalBottomNavigateBar from '@/src/widgets/bottomNavigateBar/ui/ConditionalBottomNavigateBar';
 import localFont from 'next/font/local';
 import { Suspense } from 'react';
@@ -174,6 +175,7 @@ export default function RootLayout({
             <StructuredData data={medicalWebsiteStructuredData} />
             {children}
             <ConditionalBottomNavigateBar />
+            <ToastContainer />
             <LanguageSelectionModal />
             <Suspense fallback={null}>
               <Analytics />

--- a/client/e2e/encyclopedia.spec.ts
+++ b/client/e2e/encyclopedia.spec.ts
@@ -27,7 +27,7 @@ test.describe('응급 사전 (Encyclopedia)', () => {
 
     const [request] = await Promise.all([
       page.waitForRequest('**/api/encyclopedia**'),
-      searchInput.fill('fever'),
+      searchInput.pressSequentially('fever'),
     ]);
 
     expect(request.url()).toContain('search=fever');
@@ -36,7 +36,10 @@ test.describe('응급 사전 (Encyclopedia)', () => {
   test('검색 결과로 mock 데이터 렌더링', async ({ page }) => {
     const searchInput = page.locator('input').first();
 
-    await Promise.all([page.waitForResponse('**/api/encyclopedia**'), searchInput.fill('fever')]);
+    await Promise.all([
+      page.waitForResponse('**/api/encyclopedia**'),
+      searchInput.pressSequentially('fever'),
+    ]);
 
     await expect(page.getByText(MOCK_ENCYCLOPEDIA_ITEMS[0].title)).toBeVisible({ timeout: 5_000 });
   });
@@ -58,7 +61,10 @@ test.describe('응급 사전 (Encyclopedia)', () => {
   test('검색 후 여러 mock 아이템 표시', async ({ page }) => {
     const searchInput = page.locator('input').first();
 
-    await Promise.all([page.waitForResponse('**/api/encyclopedia**'), searchInput.fill('a')]);
+    await Promise.all([
+      page.waitForResponse('**/api/encyclopedia**'),
+      searchInput.pressSequentially('a'),
+    ]);
 
     // mock 응답의 모든 아이템이 표시됨
     for (const item of MOCK_ENCYCLOPEDIA_ITEMS) {

--- a/client/e2e/encyclopedia.spec.ts
+++ b/client/e2e/encyclopedia.spec.ts
@@ -35,10 +35,11 @@ test.describe('응급 사전 (Encyclopedia)', () => {
 
   test('검색 결과로 mock 데이터 렌더링', async ({ page }) => {
     const searchInput = page.locator('input').first();
-    await searchInput.fill('fever');
 
-    // 디바운스(300ms) + 렌더링 대기
-    await page.waitForTimeout(500);
+    await Promise.all([
+      page.waitForResponse('**/api/encyclopedia**'),
+      searchInput.fill('fever'),
+    ]);
 
     await expect(page.getByText(MOCK_ENCYCLOPEDIA_ITEMS[0].title)).toBeVisible({ timeout: 5_000 });
   });
@@ -59,8 +60,11 @@ test.describe('응급 사전 (Encyclopedia)', () => {
 
   test('검색 후 여러 mock 아이템 표시', async ({ page }) => {
     const searchInput = page.locator('input').first();
-    await searchInput.fill('a');
-    await page.waitForTimeout(500);
+
+    await Promise.all([
+      page.waitForResponse('**/api/encyclopedia**'),
+      searchInput.fill('a'),
+    ]);
 
     // mock 응답의 모든 아이템이 표시됨
     for (const item of MOCK_ENCYCLOPEDIA_ITEMS) {

--- a/client/e2e/encyclopedia.spec.ts
+++ b/client/e2e/encyclopedia.spec.ts
@@ -36,10 +36,7 @@ test.describe('응급 사전 (Encyclopedia)', () => {
   test('검색 결과로 mock 데이터 렌더링', async ({ page }) => {
     const searchInput = page.locator('input').first();
 
-    await Promise.all([
-      page.waitForResponse('**/api/encyclopedia**'),
-      searchInput.fill('fever'),
-    ]);
+    await Promise.all([page.waitForResponse('**/api/encyclopedia**'), searchInput.fill('fever')]);
 
     await expect(page.getByText(MOCK_ENCYCLOPEDIA_ITEMS[0].title)).toBeVisible({ timeout: 5_000 });
   });
@@ -61,10 +58,7 @@ test.describe('응급 사전 (Encyclopedia)', () => {
   test('검색 후 여러 mock 아이템 표시', async ({ page }) => {
     const searchInput = page.locator('input').first();
 
-    await Promise.all([
-      page.waitForResponse('**/api/encyclopedia**'),
-      searchInput.fill('a'),
-    ]);
+    await Promise.all([page.waitForResponse('**/api/encyclopedia**'), searchInput.fill('a')]);
 
     // mock 응답의 모든 아이템이 표시됨
     for (const item of MOCK_ENCYCLOPEDIA_ITEMS) {

--- a/client/e2e/translate.spec.ts
+++ b/client/e2e/translate.spec.ts
@@ -36,9 +36,7 @@ test.describe('AI 번역 (Translate)', () => {
     await expect(translateBtn).toBeEnabled({ timeout: 5_000 });
 
     const [request] = await Promise.all([
-      page.waitForRequest(
-        (req) => req.url().includes('/api/translate') && req.method() === 'POST',
-      ),
+      page.waitForRequest((req) => req.url().includes('/api/translate') && req.method() === 'POST'),
       translateBtn.click(),
     ]);
     expect(request.postDataJSON()).toMatchObject({ text: 'I have a headache' });

--- a/client/e2e/translate.spec.ts
+++ b/client/e2e/translate.spec.ts
@@ -25,7 +25,7 @@ test.describe('AI 번역 (Translate)', () => {
 
   test('번역 버튼 클릭 시 /api/translate POST 호출', async ({ page }) => {
     const textarea = page.locator('textarea').first();
-    await textarea.fill('I have a headache');
+    await textarea.pressSequentially('I have a headache');
 
     const translateBtn = page
       .locator('button')
@@ -44,7 +44,7 @@ test.describe('AI 번역 (Translate)', () => {
 
   test('번역 결과 표시 (mock 응답)', async ({ page }) => {
     const textarea = page.locator('textarea').first();
-    await textarea.fill('I have a headache');
+    await textarea.pressSequentially('I have a headache');
 
     const translateBtn = page
       .locator('button')

--- a/client/src/apps/provider/ReactQueryProvider.tsx
+++ b/client/src/apps/provider/ReactQueryProvider.tsx
@@ -3,6 +3,7 @@
 import {
   DehydratedState,
   HydrationBoundary,
+  MutationCache,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
@@ -17,6 +18,9 @@ export default function ReactQueryProvider({ children, dehydratedState }: Props)
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        mutationCache: new MutationCache({
+          onError: () => {},
+        }),
         defaultOptions: {
           queries: {
             staleTime: 60 * 1000, // 1분

--- a/client/src/features/auth/api/useLoginMutation.ts
+++ b/client/src/features/auth/api/useLoginMutation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpClient } from '@/src/shared/utils/httpClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -19,13 +20,14 @@ export const useLoginMutation = () => {
   return useMutation({
     mutationFn: loginUser,
     onSuccess: () => {
+      toast.success('Logged in successfully.');
       queryClient.invalidateQueries({ queryKey: ['auth', 'isLoggedIn'] });
       queryClient.invalidateQueries({ queryKey: ['profile'] });
       router.push('/');
     },
     onError: (error) => {
       if (error instanceof APIError) {
-        console.error('Login failed:', error.message);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/features/auth/api/useLogoutMutation.ts
+++ b/client/src/features/auth/api/useLogoutMutation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpClient } from '@/src/shared/utils/httpClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -10,13 +11,14 @@ export const useLogoutMutation = () => {
   return useMutation({
     mutationFn: logoutUser,
     onSuccess: () => {
+      toast.success('Logged out successfully.');
       queryClient.removeQueries({ queryKey: ['auth', 'isLoggedIn'] });
       queryClient.removeQueries({ queryKey: ['profile'] });
       router.push('/');
     },
     onError: (error) => {
       if (error instanceof APIError) {
-        console.error('Logout failed:', error.message);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/features/auth/api/useSignupGoogleMutation.ts
+++ b/client/src/features/auth/api/useSignupGoogleMutation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpClient } from '@/src/shared/utils/httpClient';
 import { useMutation } from '@tanstack/react-query';
@@ -15,11 +16,12 @@ export const useSignupGoogleMutation = () => {
   return useMutation({
     mutationFn: signupGoogleUser,
     onSuccess: () => {
+      toast.success('Account created successfully.');
       router.push('/');
     },
     onError: (error) => {
       if (error instanceof APIError) {
-        console.error('Signup failed:', error.message);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/features/auth/api/useSignupMutation.ts
+++ b/client/src/features/auth/api/useSignupMutation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpClient } from '@/src/shared/utils/httpClient';
 import { useMutation } from '@tanstack/react-query';
@@ -13,7 +14,7 @@ export const useSignupMutation = () => {
     },
     onError: (error) => {
       if (error instanceof APIError) {
-        console.error('Signup failed:', error.message);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/features/auth/hooks/useLogin.ts
+++ b/client/src/features/auth/hooks/useLogin.ts
@@ -44,8 +44,8 @@ export const useLogin = () => {
 
     try {
       await loginUser(loginForm);
-    } catch (error) {
-      console.error('Login failed:', error);
+    } catch {
+      // onError에서 toast로 처리됨
     }
   };
 

--- a/client/src/features/encyclopedia/api/encyclopediaApi.ts
+++ b/client/src/features/encyclopedia/api/encyclopediaApi.ts
@@ -35,8 +35,7 @@ export async function fetchEncyclopedia(): Promise<{ total: number; items: Encyc
       next: { revalidate: 86400 },
     });
     return { total: res.data.total, items: mapItems(res.data.items) };
-  } catch (e) {
-    console.error('[encyclopedia] SSR fetch failed:', e);
+  } catch {
     return { total: 0, items: [] };
   }
 }

--- a/client/src/features/encyclopedia/ui/EncyclopediaClient.tsx
+++ b/client/src/features/encyclopedia/ui/EncyclopediaClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '@/src/shared/lib/i18n';
 import { CATEGORY_ICONS, CategoryKey, EncyclopediaItem, getCategory } from '../types';
 import { EncyclopediaCard } from './EncyclopediaCard';
@@ -28,54 +29,34 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [category, setCategory] = useState<CategoryKey>('all');
-  const [items, setItems] = useState(initialItems);
-  const [total, setTotal] = useState(initialTotal);
-  const [offset, setOffset] = useState(initialItems.length);
-  const [isLoading, setIsLoading] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
-  const skipInitialFetch = useRef(true);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedQuery(query.trim()), 300);
     return () => clearTimeout(timer);
   }, [query]);
 
-  useEffect(() => {
-    // debouncedQuery가 빈 문자열인 채로 첫 실행되면 SSR initialItems를 그대로 사용
-    // debouncedQuery가 이미 non-empty로 첫 실행되면(레이스) 건너뛰지 않고 바로 검색
-    if (skipInitialFetch.current) {
-      skipInitialFetch.current = false;
-      if (debouncedQuery === '') return;
-    }
-    let cancelled = false;
-    setIsLoading(true);
-    window.scrollTo(0, 0);
-    fetchEncyclopediaPage({ search: debouncedQuery || undefined }).then((result) => {
-      if (cancelled) return;
-      setItems(result.items);
-      setTotal(result.total);
-      setOffset(result.items.length);
-      setIsLoading(false);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [debouncedQuery]);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useInfiniteQuery({
+    queryKey: ['encyclopedia', debouncedQuery],
+    queryFn: ({ pageParam }) =>
+      fetchEncyclopediaPage({
+        search: debouncedQuery || undefined,
+        offset: pageParam,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.flatMap((p) => p.items).length;
+      return loaded < lastPage.total ? loaded : undefined;
+    },
+    initialData:
+      debouncedQuery === ''
+        ? { pages: [{ total: initialTotal, items: initialItems }], pageParams: [0] }
+        : undefined,
+    staleTime: 1000 * 60 * 5,
+  });
 
-  const loadMore = useCallback(async () => {
-    if (isLoading || offset >= total) return;
-    setIsLoading(true);
-    const result = await fetchEncyclopediaPage({
-      search: debouncedQuery || undefined,
-      offset,
-    });
-    setItems((prev) => {
-      const existingIds = new Set(prev.map((item) => item.id));
-      return [...prev, ...result.items.filter((item) => !existingIds.has(item.id))];
-    });
-    setOffset((prev) => prev + result.items.length);
-    setIsLoading(false);
-  }, [isLoading, offset, total, debouncedQuery]);
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? initialTotal;
 
   const filtered = useMemo(() => {
     if (category === 'all') return items;
@@ -91,16 +72,20 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
   });
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [debouncedQuery]);
+
+  useEffect(() => {
     const handleScroll = () => {
-      if (isLoading || offset >= total) return;
+      if (isFetchingNextPage || !hasNextPage) return;
       const scrollY = window.scrollY;
       const windowHeight = window.innerHeight;
       const docHeight = document.documentElement.scrollHeight;
-      if (docHeight - scrollY - windowHeight < 400) loadMore();
+      if (docHeight - scrollY - windowHeight < 400) fetchNextPage();
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [isLoading, offset, total, loadMore]);
+  }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
 
   return (
     <div className='bg-slate-50'>
@@ -175,7 +160,7 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
 
       {/* 가상화 리스트 */}
       <div className='mx-auto w-full max-w-3xl px-2 pb-4'>
-        {isLoading && items.length === 0 ? (
+        {isPending ? (
           <div className='flex h-64 items-center justify-center text-gray-400'>
             <span className='text-3xl'>⏳</span>
           </div>
@@ -209,7 +194,7 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
                 );
               })}
             </div>
-            {isLoading && (
+            {isFetchingNextPage && (
               <div className='py-3 text-center text-sm text-gray-400'>불러오는 중...</div>
             )}
           </>

--- a/client/src/features/encyclopedia/ui/EncyclopediaClient.tsx
+++ b/client/src/features/encyclopedia/ui/EncyclopediaClient.tsx
@@ -33,7 +33,7 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
   const [offset, setOffset] = useState(initialItems.length);
   const [isLoading, setIsLoading] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
-  const isFirstRender = useRef(true);
+  const skipInitialFetch = useRef(true);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedQuery(query.trim()), 300);
@@ -41,9 +41,11 @@ export function EncyclopediaClient({ initialItems, total: initialTotal }: Props)
   }, [query]);
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
+    // debouncedQuery가 빈 문자열인 채로 첫 실행되면 SSR initialItems를 그대로 사용
+    // debouncedQuery가 이미 non-empty로 첫 실행되면(레이스) 건너뛰지 않고 바로 검색
+    if (skipInitialFetch.current) {
+      skipInitialFetch.current = false;
+      if (debouncedQuery === '') return;
     }
     let cancelled = false;
     setIsLoading(true);

--- a/client/src/features/googleMap/utils/goToCurrentLocation.ts
+++ b/client/src/features/googleMap/utils/goToCurrentLocation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { findNearbyPlaces } from './findNearbyPlaces';
 type GoToCurrentLocationParams = {
   mapInstance: google.maps.Map | null;
@@ -8,7 +9,7 @@ export const goToCurrentLocation = ({ mapInstance, service }: GoToCurrentLocatio
   if (!mapInstance || !service) return;
 
   if (!navigator.geolocation) {
-    alert('Geolocation is not supported by this browser.');
+    toast.error('Geolocation is not supported by this browser.');
     return;
   }
 
@@ -16,13 +17,9 @@ export const goToCurrentLocation = ({ mapInstance, service }: GoToCurrentLocatio
     ?.query({ name: 'geolocation' })
     .then((result) => {
       if (result.state === 'denied') {
-        alert(
+        toast.error(
           'Location access is denied. Please enable location permissions in your browser settings to use this feature.',
         );
-        return;
-      }
-      if (result.state === 'prompt') {
-        // Permission will be requested when getCurrentPosition is called
       }
     })
     .catch(() => {
@@ -58,7 +55,7 @@ export const goToCurrentLocation = ({ mapInstance, service }: GoToCurrentLocatio
           message += 'An unknown error occurred.';
           break;
       }
-      alert(message);
+      toast.error(message);
     },
     {
       enableHighAccuracy: true,

--- a/client/src/features/profile/api/useEditProfileMutation.ts
+++ b/client/src/features/profile/api/useEditProfileMutation.ts
@@ -1,3 +1,4 @@
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import { APIError } from '@/src/shared/utils/apiError';
 import { httpClient } from '@/src/shared/utils/httpClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -13,8 +14,7 @@ export const useEditProfileMutation = () => {
       }
     },
     onSuccess: () => {
-      // TODO: 토스트로 변경 필요
-      alert('Profile updated successfully');
+      toast.success('Profile updated successfully');
       queryClient.invalidateQueries({ queryKey: ['profile'] });
     },
   });

--- a/client/src/shared/hooks/useToastStore.ts
+++ b/client/src/shared/hooks/useToastStore.ts
@@ -1,0 +1,7 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { toastStore } from '../lib/toast/toastStore';
+
+export const useToastStore = () =>
+  useSyncExternalStore(toastStore.subscribe, toastStore.getSnapshot, toastStore.getServerSnapshot);

--- a/client/src/shared/lib/toast/toastStore.ts
+++ b/client/src/shared/lib/toast/toastStore.ts
@@ -1,0 +1,40 @@
+export type ToastType = 'success' | 'error' | 'info';
+
+export type Toast = {
+  id: string;
+  message: string;
+  type: ToastType;
+};
+
+type Listener = () => void;
+
+let toasts: Toast[] = [];
+const EMPTY_TOASTS: Toast[] = [];
+const listeners = new Set<Listener>();
+
+const notify = () => listeners.forEach((l) => l());
+
+export const toastStore = {
+  subscribe: (listener: Listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot: (): Toast[] => toasts,
+  getServerSnapshot: (): Toast[] => EMPTY_TOASTS,
+  add: (message: string, type: ToastType = 'info', duration = 3000) => {
+    const id = crypto.randomUUID();
+    toasts = [...toasts, { id, message, type }];
+    notify();
+    setTimeout(() => toastStore.remove(id), duration);
+  },
+  remove: (id: string) => {
+    toasts = toasts.filter((t) => t.id !== id);
+    notify();
+  },
+};
+
+export const toast = {
+  success: (message: string) => toastStore.add(message, 'success'),
+  error: (message: string) => toastStore.add(message, 'error'),
+  info: (message: string) => toastStore.add(message, 'info'),
+};

--- a/client/src/shared/ui/ToastContainer.tsx
+++ b/client/src/shared/ui/ToastContainer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useToastStore } from '../hooks/useToastStore';
+import { toastStore } from '../lib/toast/toastStore';
+
+const TYPE_STYLES = {
+  success: 'bg-green-500',
+  error: 'bg-red-500',
+  info: 'bg-gray-700',
+};
+
+const ICONS = {
+  success: '✓',
+  error: '✕',
+  info: 'ℹ',
+};
+
+export function ToastContainer() {
+  const toasts = useToastStore();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className='fixed right-4 top-20 z-[9999] flex flex-col gap-2'>
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role='alert'
+          className={`flex min-w-64 max-w-80 items-start gap-3 rounded-xl px-4 py-3 text-sm font-medium text-white shadow-xl ${TYPE_STYLES[t.type]}`}
+          onClick={() => toastStore.remove(t.id)}
+        >
+          <span className='mt-0.5 text-base'>{ICONS[t.type]}</span>
+          <span className='leading-snug'>{t.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/shared/ui/ToastContainer.tsx
+++ b/client/src/shared/ui/ToastContainer.tsx
@@ -21,12 +21,12 @@ export function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className='fixed right-4 top-20 z-[9999] flex flex-col gap-2'>
+    <div className='fixed top-20 right-4 z-[9999] flex flex-col gap-2'>
       {toasts.map((t) => (
         <div
           key={t.id}
           role='alert'
-          className={`flex min-w-64 max-w-80 items-start gap-3 rounded-xl px-4 py-3 text-sm font-medium text-white shadow-xl ${TYPE_STYLES[t.type]}`}
+          className={`flex max-w-80 min-w-64 items-start gap-3 rounded-xl px-4 py-3 text-sm font-medium text-white shadow-xl ${TYPE_STYLES[t.type]}`}
           onClick={() => toastStore.remove(t.id)}
         >
           <span className='mt-0.5 text-base'>{ICONS[t.type]}</span>

--- a/client/src/shared/utils/httpServer.ts
+++ b/client/src/shared/utils/httpServer.ts
@@ -7,7 +7,8 @@ async function request<T = unknown>(url: string, config: FetchConfig = {}): Prom
   const { method = 'GET', headers = {}, body, next } = config;
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  const timeoutMs = process.env.CI ? 2000 : 10000;
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(`${BASE_URL}${url}`, {

--- a/client/src/widgets/navbar/Navbar.tsx
+++ b/client/src/widgets/navbar/Navbar.tsx
@@ -42,7 +42,9 @@ const LanguageDropdown = () => {
   const handleLanguageChange = async (langCode: string) => {
     setIsOpen(false);
     if (pathname.startsWith('/about')) {
-      toast.success(langCode === 'ko' ? '한국어로 변경되었습니다.' : 'Language changed to English.');
+      toast.success(
+        langCode === 'ko' ? '한국어로 변경되었습니다.' : 'Language changed to English.',
+      );
       router.push(`/about/${langCode}`);
       return;
     }

--- a/client/src/widgets/navbar/Navbar.tsx
+++ b/client/src/widgets/navbar/Navbar.tsx
@@ -133,6 +133,7 @@ export default function Navbar({ navTranslations }: { navTranslations?: NavTrans
                 src='/VitalTrip.svg'
                 alt='VitalTrip Logo'
                 className='h-12 w-auto'
+                style={{ width: 'auto' }}
                 width={48}
                 height={48}
               />

--- a/client/src/widgets/navbar/Navbar.tsx
+++ b/client/src/widgets/navbar/Navbar.tsx
@@ -6,6 +6,7 @@ import { useProfileQuery } from '@/src/features/profile/api/useProfileQuery';
 
 import { useHydration } from '@/src/shared/hooks/useHydration';
 import { useTranslation } from '@/src/shared/lib/i18n';
+import { toast } from '@/src/shared/lib/toast/toastStore';
 import Dropdown from '@/src/shared/ui/Dropdown';
 import { FaBars, FaChevronDown, FaTimes } from '@/src/shared/ui/icons';
 import { AnimatePresence, motion } from 'motion/react';
@@ -41,11 +42,13 @@ const LanguageDropdown = () => {
   const handleLanguageChange = async (langCode: string) => {
     setIsOpen(false);
     if (pathname.startsWith('/about')) {
+      toast.success(langCode === 'ko' ? '한국어로 변경되었습니다.' : 'Language changed to English.');
       router.push(`/about/${langCode}`);
       return;
     }
     await i18n.loadLanguages(langCode);
     await i18n.changeLanguage(langCode);
+    toast.success(langCode === 'ko' ? '한국어로 변경되었습니다.' : 'Language changed to English.');
   };
 
   const displayLanguage = isHydrated ? currentLanguage : languages[0];

--- a/client/src/widgets/navbar/Navbar.tsx
+++ b/client/src/widgets/navbar/Navbar.tsx
@@ -132,8 +132,7 @@ export default function Navbar({ navTranslations }: { navTranslations?: NavTrans
               <Image
                 src='/VitalTrip.svg'
                 alt='VitalTrip Logo'
-                className='h-12 w-auto'
-                style={{ width: 'auto' }}
+                style={{ height: '3rem', width: 'auto' }}
                 width={48}
                 height={48}
               />

--- a/client/src/widgets/signup/Signup1.tsx
+++ b/client/src/widgets/signup/Signup1.tsx
@@ -3,6 +3,7 @@
 import { useCheckEmail } from '@/src/features/auth/hooks/useCheckEmail';
 import type { SignupErrors } from '@/src/features/auth/types/signup';
 import { CheckEmailButton } from '@/src/features/auth/ui/CheckEmailButton';
+import { toast } from '@/src/shared/lib/toast/toastStore';
 
 interface FormData {
   email: string;
@@ -35,7 +36,7 @@ export default function Signup1({
     e.preventDefault();
 
     if (formData.password !== formData.passwordConfirm) {
-      alert('Passwords do not match.');
+      toast.error('Passwords do not match.');
       return;
     }
 


### PR DESCRIPTION
## 개요

Closes #122

기존 `alert()` / `console.error()` 를 제거하고, `useSyncExternalStore` 기반 토스트 알림 시스템을 구현했습니다.

---

## 설계

### 왜 useSyncExternalStore인가

토스트는 React 컴포넌트 트리 바깥(mutation 콜백, 유틸 함수 등)에서 호출될 수 있어야 합니다. Context나 useState를 쓰면 컴포넌트 안에서만 상태를 변경할 수 있으므로, **모듈 레벨 싱글톤 + useSyncExternalStore** 패턴을 선택했습니다.

```
toast.success('...')         ← 어디서든 호출 가능 (훅 바깥 포함)
      ↓
toastStore.add()             ← 모듈 변수 toasts 업데이트 + notify()
      ↓
listeners.forEach(l => l())  ← useSyncExternalStore가 등록한 리스너 호출
      ↓
ToastContainer 리렌더         ← getSnapshot()으로 최신 상태 읽음
```

### 스토어 구조

`useSyncExternalStore`가 요구하는 인터페이스를 그대로 스토어 객체로 구현했습니다.

```ts
// toastStore.ts
let toasts: Toast[] = [];
const listeners = new Set<Listener>();

export const toastStore = {
  subscribe: (listener) => {          // useSyncExternalStore에 넘기는 구독 함수
    listeners.add(listener);
    return () => listeners.delete(listener);
  },
  getSnapshot: () => toasts,          // 클라이언트 스냅샷
  getServerSnapshot: () => EMPTY_TOASTS, // SSR 스냅샷 (항상 빈 배열)
  add: (message, type, duration) => {
    toasts = [...toasts, { id, message, type }]; // 새 참조 → React가 변경 감지
    notify();
    setTimeout(() => toastStore.remove(id), duration);
  },
};
```

`toasts = [...toasts, newToast]` 로 매번 새 배열 참조를 만드는 이유는 `useSyncExternalStore`가 `Object.is`로 스냅샷 변경을 감지하기 때문입니다.

`EMPTY_TOASTS`를 별도 상수로 분리한 이유는 `getServerSnapshot`이 매 호출마다 새 `[]`를 반환하면 SSR tearing 경고가 발생할 수 있기 때문입니다.

### 레이어 분리

| 파일 | 역할 |
|------|------|
| `toastStore.ts` | 순수 JS 싱글톤. React 의존성 없음. 어디서든 import 가능 |
| `useToastStore.ts` | `useSyncExternalStore` 래핑. React 구독 담당 |
| `ToastContainer.tsx` | 렌더링만 담당. 클릭 dismiss, 타입별 아이콘/색상 |

`toast.success()` / `toast.error()` / `toast.info()` 헬퍼로 호출부 코드를 단순하게 유지했습니다.

---

## 교체 내역

| 이전 | 이후 |
|------|------|
| `alert('...')` | `toast.error('...')` |
| `console.error('...')` | `toast.error('...')` |
| `// TODO: 토스트로 변경` | `toast.success('...')` |
| 성공 알림 없음 | `toast.success('...')` |

적용 범위: 로그인·로그아웃·구글 로그인·회원가입·프로필 수정·위치 권한 오류·언어 변경

---

## Test plan

- [ ] 로그인 성공 → 우상단 초록 토스트
- [ ] 로그아웃 성공 → 우상단 초록 토스트
- [ ] 로그인 실패 → 우상단 빨간 토스트
- [ ] 프로필 수정 성공 → 우상단 초록 토스트
- [ ] 언어 변경 → 우상단 초록 토스트
- [ ] 위치 접근 거부 → 우상단 빨간 토스트
- [ ] 토스트 클릭 시 즉시 닫힘
- [ ] 3초 후 자동 소멸